### PR TITLE
fix: wrap floating captions while streaming

### DIFF
--- a/Sources/AirTranslate/Support/FloatingCaptionTextFormatter.swift
+++ b/Sources/AirTranslate/Support/FloatingCaptionTextFormatter.swift
@@ -1,29 +1,39 @@
 import Foundation
 
+private enum FloatingCaptionTextLayout {
+    // Approximate readable caption width: about 42 ASCII chars or 26 CJK chars.
+    static let lineWidthUnits = 26.0
+    static let scanLineMultiplier = 4
+
+    static func displayWidth(of character: Character) -> Double {
+        if character.isWhitespace {
+            return 0.45
+        }
+
+        guard let scalar = character.unicodeScalars.first else {
+            return 1
+        }
+
+        return scalar.isASCII ? 0.62 : 1
+    }
+}
+
 extension String {
     func floatingCaptionTail(maxLines: Int) -> String {
         let maxLines = max(1, maxLines)
         let trimmedText = trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedText.isEmpty else { return "" }
-        let maxCharacters = maxLines * 72
+        let scanCharacters = maxLines * 72 * FloatingCaptionTextLayout.scanLineMultiplier
         let captionText = trimmedText.floatingCaptionSentenceBreaks()
-        let scanText = String(captionText.boundedSuffix(maxCharacters: maxCharacters * 3))
+        let scanText = String(captionText.boundedSuffix(maxCharacters: scanCharacters))
 
-        let logicalLines = scanText
-            .components(separatedBy: .newlines)
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { !$0.isEmpty }
+        let logicalLines = scanText.floatingCaptionWrappedLines(
+            maxLineWidth: FloatingCaptionTextLayout.lineWidthUnits
+        )
 
-        let tailText: String
-        if logicalLines.count > maxLines {
-            tailText = logicalLines.suffix(maxLines).joined(separator: "\n")
-        } else {
-            tailText = scanText
-        }
-
-        guard tailText.count > maxCharacters else { return tailText }
-
-        return String(tailText.suffix(maxCharacters))
+        return logicalLines
+            .suffix(maxLines)
+            .joined(separator: "\n")
             .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
@@ -39,9 +49,92 @@ extension String {
 
     private func floatingCaptionSentenceBreaks() -> String {
         replacingOccurrences(
-            of: #"(?<!\d)\.\s+(?=\S)"#,
-            with: ".\n",
+            of: #"(?<!\d)([.!?。！？])\s+(?=\S)"#,
+            with: "$1\n",
             options: .regularExpression
         )
+    }
+
+    private func floatingCaptionWrappedLines(maxLineWidth: Double) -> [String] {
+        components(separatedBy: .newlines)
+            .flatMap { paragraph in
+                paragraph.floatingCaptionWrappedParagraph(maxLineWidth: maxLineWidth)
+            }
+            .filter { !$0.isEmpty }
+    }
+
+    private func floatingCaptionWrappedParagraph(maxLineWidth: Double) -> [String] {
+        let paragraph = trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !paragraph.isEmpty else { return [] }
+
+        var lines: [String] = []
+        var currentLine = ""
+        var currentWidth = 0.0
+
+        for word in paragraph.split(whereSeparator: \.isWhitespace) {
+            let word = String(word)
+            let wordWidth = word.floatingCaptionDisplayWidth
+
+            if wordWidth > maxLineWidth {
+                if !currentLine.isEmpty {
+                    lines.append(currentLine)
+                    currentLine = ""
+                    currentWidth = 0
+                }
+                lines.append(contentsOf: word.floatingCaptionSplitLongToken(maxLineWidth: maxLineWidth))
+                continue
+            }
+
+            let separatorWidth = currentLine.isEmpty ? 0 : FloatingCaptionTextLayout.displayWidth(of: " ")
+            let nextWidth = currentWidth + separatorWidth + wordWidth
+            if !currentLine.isEmpty, nextWidth > maxLineWidth {
+                lines.append(currentLine)
+                currentLine = word
+                currentWidth = wordWidth
+            } else {
+                if !currentLine.isEmpty {
+                    currentLine += " "
+                    currentWidth += separatorWidth
+                }
+                currentLine += word
+                currentWidth += wordWidth
+            }
+        }
+
+        if !currentLine.isEmpty {
+            lines.append(currentLine)
+        }
+
+        return lines
+    }
+
+    private var floatingCaptionDisplayWidth: Double {
+        reduce(0) { width, character in
+            width + FloatingCaptionTextLayout.displayWidth(of: character)
+        }
+    }
+
+    private func floatingCaptionSplitLongToken(maxLineWidth: Double) -> [String] {
+        var lines: [String] = []
+        var currentLine = ""
+        var currentWidth = 0.0
+
+        for character in self {
+            let characterWidth = FloatingCaptionTextLayout.displayWidth(of: character)
+            if !currentLine.isEmpty, currentWidth + characterWidth > maxLineWidth {
+                lines.append(currentLine)
+                currentLine = ""
+                currentWidth = 0
+            }
+
+            currentLine.append(character)
+            currentWidth += characterWidth
+        }
+
+        if !currentLine.isEmpty {
+            lines.append(currentLine)
+        }
+
+        return lines
     }
 }

--- a/Sources/AirTranslate/Support/FloatingCaptionTextFormatter.swift
+++ b/Sources/AirTranslate/Support/FloatingCaptionTextFormatter.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 private enum FloatingCaptionTextLayout {
-    // Approximate readable caption width: about 42 ASCII chars or 26 CJK chars.
-    static let lineWidthUnits = 26.0
+    // Approximate readable caption width: about 63 ASCII chars or 39 CJK chars.
+    static let lineWidthUnits = 39.0
     static let scanLineMultiplier = 4
 
     static func displayWidth(of character: Character) -> Double {

--- a/Tests/AirTranslateCoreTests/FloatingCaptionTextFormatterTests.swift
+++ b/Tests/AirTranslateCoreTests/FloatingCaptionTextFormatterTests.swift
@@ -18,6 +18,15 @@ struct FloatingCaptionTextFormatterTests {
     }
 
     @Test
+    func floatingCaptionTailKeepsMediumEnglishCaptionOnOneLine() {
+        let text = "This caption should stay on one line with the wider threshold."
+
+        let caption = text.floatingCaptionTail(maxLines: 2)
+
+        #expect(caption == text)
+    }
+
+    @Test
     func floatingCaptionTailWrapsCJKTextWithoutWhitespace() {
         let text = "감가상각비와이연법인세회계처리를연속해서설명하는강의문장이길어져도자막창에서는읽기좋게나뉘어야합니다"
 

--- a/Tests/AirTranslateCoreTests/FloatingCaptionTextFormatterTests.swift
+++ b/Tests/AirTranslateCoreTests/FloatingCaptionTextFormatterTests.swift
@@ -1,0 +1,44 @@
+import Testing
+@testable import AirTranslate
+
+@Suite
+struct FloatingCaptionTextFormatterTests {
+    @Test
+    func floatingCaptionTailWrapsLongEnglishCaptionWhileKeepingRecentLines() {
+        let text = """
+        This lecture introduces depreciation methods and deferred tax accounting before moving into practice questions for the next topic.
+        """
+
+        let caption = text.floatingCaptionTail(maxLines: 3)
+        let lines = caption.split(separator: "\n", omittingEmptySubsequences: true)
+
+        #expect(lines.count > 1)
+        #expect(lines.count <= 3)
+        #expect(caption.contains("deferred tax"))
+    }
+
+    @Test
+    func floatingCaptionTailWrapsCJKTextWithoutWhitespace() {
+        let text = "감가상각비와이연법인세회계처리를연속해서설명하는강의문장이길어져도자막창에서는읽기좋게나뉘어야합니다"
+
+        let caption = text.floatingCaptionTail(maxLines: 3)
+        let lines = caption.split(separator: "\n", omittingEmptySubsequences: true)
+
+        #expect(lines.count > 1)
+        #expect(lines.count <= 3)
+        #expect(lines.allSatisfy { !$0.isEmpty })
+    }
+
+    @Test
+    func floatingCaptionTailBreaksAfterCommonSentencePunctuation() {
+        let text = "First idea appears. Second idea follows? Third idea lands!"
+
+        let caption = text.floatingCaptionTail(maxLines: 3)
+
+        #expect(caption == """
+        First idea appears.
+        Second idea follows?
+        Third idea lands!
+        """)
+    }
+}


### PR DESCRIPTION
## Summary
- Wrap floating caption text into readable lines while captions are still streaming.
- Keep the existing max line count behavior by returning only the latest wrapped lines.
- Add coverage for English wrapping, Korean/CJK text without spaces, and common sentence punctuation.

## Verification
- swift build: pass
- swift test: blocked before this change because the Command Line Tools environment cannot import Swift Testing's Testing module.
- Frontend employee read-only verification: PASS, no blocking findings.