### PR TITLE
fix: improve transcribe-only mode behavior

### DIFF
--- a/Sources/AirTranslate/Models/AppText.swift
+++ b/Sources/AirTranslate/Models/AppText.swift
@@ -297,6 +297,19 @@ enum AppText {
         korean: "OpenAI 실시간 번역"
     )
     static let output = localized(english: "Output", korean: "출력", japanese: "出力", chineseSimplified: "输出")
+    static let outputMode = localized(english: "Output Mode", korean: "출력 모드", japanese: "出力モード", chineseSimplified: "输出模式")
+    static let transcribeOnly = localized(
+        english: "Transcribe Only",
+        korean: "전사만",
+        japanese: "文字起こしのみ",
+        chineseSimplified: "仅转写"
+    )
+    static let transcriptionSettings = localized(
+        english: "Transcription Settings",
+        korean: "전사 설정",
+        japanese: "文字起こし設定",
+        chineseSimplified: "转写设置"
+    )
     static let translationSettings = localized(english: "Translation Settings", korean: "번역 설정", japanese: "翻訳設定", chineseSimplified: "翻译设置")
     static let configureTranslationSettings = localized(
         english: "Configure Translation Settings",
@@ -536,6 +549,15 @@ enum AppText {
 
     static func languageSummary(source: String, target: String) -> String {
         localized(english: "\(source) to \(target)", korean: "\(source) → \(target)")
+    }
+
+    static func transcribeLanguageSummary(source: String) -> String {
+        localized(
+            english: "Transcribe \(source)",
+            korean: "\(source) 전사",
+            japanese: "\(source) の文字起こし",
+            chineseSimplified: "转写\(source)"
+        )
     }
 
     static func openAILanguageSummary(target: String) -> String {

--- a/Sources/AirTranslate/Models/LiveOutputMode.swift
+++ b/Sources/AirTranslate/Models/LiveOutputMode.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+enum LiveOutputMode: String, CaseIterable, Identifiable {
+    case translation
+    case transcription
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .translation:
+            AppText.translation
+        case .transcription:
+            AppText.transcribeOnly
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .translation:
+            "character.bubble"
+        case .transcription:
+            "waveform"
+        }
+    }
+}

--- a/Sources/AirTranslate/Services/TranslationSessionStore.swift
+++ b/Sources/AirTranslate/Services/TranslationSessionStore.swift
@@ -671,6 +671,10 @@ final class TranslationSessionStore {
         isRunning || !lines.isEmpty
     }
 
+    var shouldShowTranslationPane: Bool {
+        selectedModel != .appleSpeechOnly
+    }
+
     var selectedSavedTranscript: SavedTranscript? {
         guard let selectedSavedTranscriptID else { return nil }
         return savedTranscripts.first { $0.id == selectedSavedTranscriptID }

--- a/Sources/AirTranslate/Services/TranslationSessionStore.swift
+++ b/Sources/AirTranslate/Services/TranslationSessionStore.swift
@@ -83,6 +83,7 @@ final class TranslationSessionStore {
     private static let floatingCaptionImmediateExtensionCharacterLimit = 28
     private static let minimumFloatingCaptionDwell = 1.4
     private static let maximumFloatingCaptionDwell = 3.6
+    private static let transcribeOnlyNoticeDisplayDuration: TimeInterval = 10
     private static let appleAutoDetectionMinimumConfidence = 0.35
     private static let appleAutoDetectionLanguageSwitchMinimumConfidence = 0.72
     private static let isAppleSourceAutoDetectionTemporarilyDisabled = true
@@ -111,6 +112,7 @@ final class TranslationSessionStore {
             resetTranslationCache()
             resetDubbingProgress()
             refreshModelAvailability()
+            syncLiveOutputModeWithLanguagePair()
         }
     }
     var targetLanguage = LanguageOption.supported[1] {
@@ -119,6 +121,7 @@ final class TranslationSessionStore {
             resetTranslationCache()
             resetDubbingProgress()
             refreshModelAvailability()
+            syncLiveOutputModeWithLanguagePair()
         }
     }
     var selectedModel = IntelligenceModel.appleSystem {
@@ -190,6 +193,7 @@ final class TranslationSessionStore {
     var statusMessage = AppText.ready
     var toastMessage: String?
     var toastSequence = 0
+    var floatingNoticeText: String?
     var lines: [CaptionLine] = []
     var savedTranscripts: [SavedTranscript] = []
     var selectedSavedTranscriptID: String?
@@ -253,10 +257,13 @@ final class TranslationSessionStore {
     private var isRestoringSelectedSettings = false
     private var modelAvailabilityTask: Task<Void, Never>?
     private var toastDismissTask: Task<Void, Never>?
+    private var transcribeOnlyNoticeDismissTask: Task<Void, Never>?
     private var captureStartTask: Task<Void, Never>?
     private var lastSpokenTranslatedText = ""
     private var spokenTranslationUnitKeys: Set<String> = []
     private var spokenTranslationUnitKeyOrder: [String] = []
+    private var hasShownTranscribeOnlyNoticeForCurrentActivation = false
+    private var floatingCaptionDisplayModeBeforeTranscribeOnly: FloatingCaptionDisplayMode?
 
     private enum SavedTranscriptPart {
         case original
@@ -277,6 +284,14 @@ final class TranslationSessionStore {
 
     var isUsingOpenAIRealtimeTranslation: Bool {
         openAITranslationModel.usesRealtimeAudioTranslation
+    }
+
+    var isTranscribeOnlyMode: Bool {
+        selectedModel == .appleSpeechOnly && !isUsingOpenAIRealtime
+    }
+
+    var liveOutputMode: LiveOutputMode {
+        isTranscribeOnlyMode ? .transcription : .translation
     }
 
     private struct SavedTranscriptFile {
@@ -544,6 +559,9 @@ final class TranslationSessionStore {
     }
 
     var languageSummary: String {
+        if isTranscribeOnlyMode {
+            return AppText.transcribeLanguageSummary(source: sourceLanguage.localizedTitle)
+        }
         if isUsingOpenAIRealtimeTranslation {
             return AppText.openAILanguageSummary(target: targetLanguage.localizedTitle)
         }
@@ -572,12 +590,14 @@ final class TranslationSessionStore {
     }
 
     func useAppleDefaultMode() {
+        clearTranscribeOnlyNotice(resetActivation: true)
         selectedModel = .appleSystem
         openAITranscriptionModel = .off
         openAITranslationModel = .off
     }
 
     func useGPTRealtimeMode() {
+        clearTranscribeOnlyNotice(resetActivation: true)
         selectedModel = .appleSystem
         isTranscriptLintEnabled = false
         if !openAITranscriptionModel.isEnabled {
@@ -587,6 +607,89 @@ final class TranslationSessionStore {
             openAITranslationModel = .gptRealtimeTranslate
         }
         usePreferredLanguageForOpenAIOutput()
+    }
+
+    func useLiveOutputMode(_ mode: LiveOutputMode) {
+        switch mode {
+        case .translation:
+            useTranslationMode()
+        case .transcription:
+            useTranscribeOnlyMode()
+        }
+    }
+
+    func useTranslationMode() {
+        clearTranscribeOnlyNotice(resetActivation: true)
+        if selectedModel == .appleSpeechOnly {
+            selectedModel = .appleSystem
+        }
+        restoreFloatingCaptionDisplayModeAfterTranscribeOnly()
+    }
+
+    func useTranscribeOnlyMode() {
+        if floatingCaptionDisplayModeBeforeTranscribeOnly == nil {
+            floatingCaptionDisplayModeBeforeTranscribeOnly = floatingCaptionDisplayMode
+        }
+        floatingCaptionDisplayMode = .original
+        openAITranscriptionModel = .off
+        openAITranslationModel = .off
+        isDubbingEnabled = false
+        selectedModel = .appleSpeechOnly
+        clearTranscribeOnlyNotice(resetActivation: true)
+    }
+
+    private func syncLiveOutputModeWithLanguagePair() {
+        guard !isRestoringSelectedSettings, !isRunning, !isUsingOpenAIRealtime else { return }
+
+        if sourceLanguage == targetLanguage {
+            useTranscribeOnlyMode()
+        } else if selectedModel == .appleSpeechOnly {
+            useTranslationMode()
+        }
+    }
+
+    private func restoreFloatingCaptionDisplayModeAfterTranscribeOnly() {
+        guard let previousMode = floatingCaptionDisplayModeBeforeTranscribeOnly else { return }
+
+        floatingCaptionDisplayModeBeforeTranscribeOnly = nil
+        floatingCaptionDisplayMode = previousMode
+    }
+
+    private func showTranscribeOnlyNoticeForCurrentActivation() {
+        guard isTranscribeOnlyMode,
+              !hasShownTranscribeOnlyNoticeForCurrentActivation
+        else {
+            return
+        }
+
+        hasShownTranscribeOnlyNoticeForCurrentActivation = true
+        floatingNoticeText = AppText.translationDisabledForSpeechOnly
+        statusMessage = AppText.translationDisabledForSpeechOnly
+        transcribeOnlyNoticeDismissTask?.cancel()
+
+        transcribeOnlyNoticeDismissTask = Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(Int(Self.transcribeOnlyNoticeDisplayDuration * 1_000)))
+            guard !Task.isCancelled else { return }
+
+            if floatingNoticeText == AppText.translationDisabledForSpeechOnly {
+                floatingNoticeText = nil
+            }
+            if statusMessage == AppText.translationDisabledForSpeechOnly {
+                statusMessage = isRunning ? AppText.listeningForSpeech(from: audioInputSource) : AppText.ready
+            }
+            transcribeOnlyNoticeDismissTask = nil
+        }
+    }
+
+    private func clearTranscribeOnlyNotice(resetActivation: Bool) {
+        transcribeOnlyNoticeDismissTask?.cancel()
+        transcribeOnlyNoticeDismissTask = nil
+        if floatingNoticeText == AppText.translationDisabledForSpeechOnly {
+            floatingNoticeText = nil
+        }
+        if resetActivation {
+            hasShownTranscribeOnlyNoticeForCurrentActivation = false
+        }
     }
 
     func modelAvailability(for model: IntelligenceModel) -> ModelAvailability {
@@ -672,7 +775,7 @@ final class TranslationSessionStore {
     }
 
     var shouldShowTranslationPane: Bool {
-        selectedModel != .appleSpeechOnly
+        !isTranscribeOnlyMode
     }
 
     var selectedSavedTranscript: SavedTranscript? {
@@ -891,6 +994,7 @@ final class TranslationSessionStore {
         translationTask = nil
         transcriptCleanupTask?.cancel()
         transcriptCleanupTask = nil
+        clearTranscribeOnlyNotice(resetActivation: clearsVisibleLines)
 
         if clearsVisibleLines {
             lines.removeAll()
@@ -2437,12 +2541,8 @@ final class TranslationSessionStore {
     private func requestTranslation(for line: CaptionLine, source: LanguageOption, target: LanguageOption) {
         guard !openAITranslationModel.usesRealtimeAudioTranslation else { return }
 
-        guard selectedModel != .appleSpeechOnly else {
-            markTranslationUnavailable(
-                AppText.translationDisabledForSpeechOnly,
-                for: line,
-                matching: line.sourceText
-            )
+        guard !isTranscribeOnlyMode else {
+            showTranscribeOnlyNoticeForCurrentActivation()
             return
         }
 

--- a/Sources/AirTranslate/Services/TranslationSessionStore.swift
+++ b/Sources/AirTranslate/Services/TranslationSessionStore.swift
@@ -264,6 +264,7 @@ final class TranslationSessionStore {
     private var spokenTranslationUnitKeyOrder: [String] = []
     private var hasShownTranscribeOnlyNoticeForCurrentActivation = false
     private var floatingCaptionDisplayModeBeforeTranscribeOnly: FloatingCaptionDisplayMode?
+    private var isUsingSameLanguageAutoTranscribeOnly = false
 
     private enum SavedTranscriptPart {
         case original
@@ -590,6 +591,7 @@ final class TranslationSessionStore {
     }
 
     func useAppleDefaultMode() {
+        isUsingSameLanguageAutoTranscribeOnly = false
         clearTranscribeOnlyNotice(resetActivation: true)
         selectedModel = .appleSystem
         openAITranscriptionModel = .off
@@ -597,6 +599,7 @@ final class TranslationSessionStore {
     }
 
     func useGPTRealtimeMode() {
+        isUsingSameLanguageAutoTranscribeOnly = false
         clearTranscribeOnlyNotice(resetActivation: true)
         selectedModel = .appleSystem
         isTranscriptLintEnabled = false
@@ -619,6 +622,7 @@ final class TranslationSessionStore {
     }
 
     func useTranslationMode() {
+        isUsingSameLanguageAutoTranscribeOnly = false
         clearTranscribeOnlyNotice(resetActivation: true)
         if selectedModel == .appleSpeechOnly {
             selectedModel = .appleSystem
@@ -627,6 +631,15 @@ final class TranslationSessionStore {
     }
 
     func useTranscribeOnlyMode() {
+        setTranscribeOnlyMode(automaticallySelectedForSameLanguagePair: false)
+    }
+
+    private func useSameLanguageAutoTranscribeOnlyMode() {
+        setTranscribeOnlyMode(automaticallySelectedForSameLanguagePair: true)
+    }
+
+    private func setTranscribeOnlyMode(automaticallySelectedForSameLanguagePair: Bool) {
+        isUsingSameLanguageAutoTranscribeOnly = automaticallySelectedForSameLanguagePair
         if floatingCaptionDisplayModeBeforeTranscribeOnly == nil {
             floatingCaptionDisplayModeBeforeTranscribeOnly = floatingCaptionDisplayMode
         }
@@ -642,8 +655,10 @@ final class TranslationSessionStore {
         guard !isRestoringSelectedSettings, !isRunning, !isUsingOpenAIRealtime else { return }
 
         if sourceLanguage == targetLanguage {
-            useTranscribeOnlyMode()
-        } else if selectedModel == .appleSpeechOnly {
+            if !isTranscribeOnlyMode {
+                useSameLanguageAutoTranscribeOnlyMode()
+            }
+        } else if isUsingSameLanguageAutoTranscribeOnly {
             useTranslationMode()
         }
     }

--- a/Sources/AirTranslate/Views/CaptionBoardView.swift
+++ b/Sources/AirTranslate/Views/CaptionBoardView.swift
@@ -117,7 +117,10 @@ private struct CaptionTranscriptFeed: View {
                     }
 
                     ForEach(session.lines) { line in
-                        CaptionLineView(line: line)
+                        CaptionLineView(
+                            line: line,
+                            showsTranslationPane: session.shouldShowTranslationPane
+                        )
                             .id(line.id)
                             .transition(.move(edge: .bottom).combined(with: .opacity))
                     }
@@ -163,30 +166,44 @@ private struct CaptionTranscriptFeed: View {
 
 private struct CaptionLineView: View {
     let line: CaptionLine
+    let showsTranslationPane: Bool
 
     var body: some View {
-        HStack(alignment: .top, spacing: 16) {
-            TranscriptPane(
-                title: AppText.original,
-                description: AppText.originalDescription,
-                text: line.sourceText,
-                displayText: line.sourceDisplayText,
-                revision: line.revision,
-                isPrimary: true
-            )
-            TranscriptPane(
-                title: AppText.translation,
-                description: AppText.translationDescription,
-                text: line.translatedText,
-                displayText: line.translatedDisplayText,
-                revision: line.revision,
-                isPrimary: false
-            )
+        Group {
+            if showsTranslationPane {
+                HStack(alignment: .top, spacing: 16) {
+                    originalPane
+                    translationPane
+                }
+            } else {
+                originalPane
+            }
         }
         .frame(maxWidth: .infinity, alignment: .topLeading)
     }
-}
 
+    private var originalPane: some View {
+        TranscriptPane(
+            title: AppText.original,
+            description: AppText.originalDescription,
+            text: line.sourceText,
+            displayText: line.sourceDisplayText,
+            revision: line.revision,
+            isPrimary: true
+        )
+    }
+
+    private var translationPane: some View {
+        TranscriptPane(
+            title: AppText.translation,
+            description: AppText.translationDescription,
+            text: line.translatedText,
+            displayText: line.translatedDisplayText,
+            revision: line.revision,
+            isPrimary: false
+        )
+    }
+}
 
 private struct TranscriptPane: View {
     let title: String

--- a/Sources/AirTranslate/Views/FloatingCaptionWindowView.swift
+++ b/Sources/AirTranslate/Views/FloatingCaptionWindowView.swift
@@ -30,19 +30,32 @@ struct FloatingCaptionWindowView: View {
         switch session.floatingCaptionDisplayMode {
         case .original:
             subtitleText(sourceText, font: session.floatingCaptionTextSize.primaryFont)
+            if !noticeText.isEmpty {
+                noticeSubtitleText(noticeText)
+            }
         case .originalAndTranslation:
             if !sourceText.isEmpty {
                 subtitleText(sourceText, font: session.floatingCaptionTextSize.secondaryFont)
                     .opacity(0.82)
-                subtitleText(translationText.isEmpty ? " " : translationText, font: session.floatingCaptionTextSize.primaryFont)
-                    .opacity(translationText.isEmpty ? 0 : 1)
+                if !translationText.isEmpty {
+                    subtitleText(translationText, font: session.floatingCaptionTextSize.primaryFont)
+                } else if !noticeText.isEmpty {
+                    noticeSubtitleText(noticeText)
+                } else {
+                    subtitleText(" ", font: session.floatingCaptionTextSize.primaryFont)
+                        .opacity(0)
+                }
             }
-            if sourceText.isEmpty && translationText.isEmpty {
+            if sourceText.isEmpty && translationText.isEmpty && noticeText.isEmpty {
                 subtitleText(AppText.noFloatingCaptionsYet, font: session.floatingCaptionTextSize.primaryFont)
+            } else if sourceText.isEmpty && translationText.isEmpty {
+                noticeSubtitleText(noticeText)
             }
         case .translation:
             if !translationText.isEmpty {
                 subtitleText(translationText, font: session.floatingCaptionTextSize.primaryFont)
+            } else if !noticeText.isEmpty {
+                noticeSubtitleText(noticeText)
             } else if sourceText.isEmpty {
                 subtitleText(AppText.noFloatingCaptionsYet, font: session.floatingCaptionTextSize.primaryFont)
             }
@@ -55,6 +68,10 @@ struct FloatingCaptionWindowView: View {
 
     private var translationText: String {
         session.floatingTranslationText
+    }
+
+    private var noticeText: String {
+        session.floatingNoticeText ?? ""
     }
 
     private var lineLimit: Int {
@@ -70,7 +87,7 @@ struct FloatingCaptionWindowView: View {
 
         switch session.floatingCaptionDisplayMode {
         case .original, .translation:
-            textHeight = primaryHeight
+            textHeight = noticeText.isEmpty ? primaryHeight : primaryHeight + secondaryHeight + 8
         case .originalAndTranslation:
             textHeight = primaryHeight + secondaryHeight + 8
         }
@@ -94,5 +111,10 @@ struct FloatingCaptionWindowView: View {
         .lineSpacing(5)
         .shadow(color: .black.opacity(0.95), radius: 3, x: 0, y: 1)
         .shadow(color: .black.opacity(0.65), radius: 8, x: 0, y: 2)
+    }
+
+    private func noticeSubtitleText(_ text: String) -> some View {
+        subtitleText(text, font: session.floatingCaptionTextSize.secondaryFont)
+            .opacity(0.78)
     }
 }

--- a/Sources/AirTranslate/Views/LiveOutputModePicker.swift
+++ b/Sources/AirTranslate/Views/LiveOutputModePicker.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+struct LiveOutputModePicker: View {
+    @Binding var selection: LiveOutputMode
+    let isDisabled: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 7) {
+                Image(systemName: selection.systemImage)
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 14)
+
+                Text(AppText.outputMode)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+
+                Spacer(minLength: 0)
+            }
+
+            Picker(AppText.outputMode, selection: $selection) {
+                ForEach(LiveOutputMode.allCases) { mode in
+                    Text(mode.title).tag(mode)
+                }
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .frame(maxWidth: .infinity)
+            .disabled(isDisabled)
+            .accessibilityLabel(AppText.outputMode)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
+    }
+}

--- a/Sources/AirTranslate/Views/SettingsView.swift
+++ b/Sources/AirTranslate/Views/SettingsView.swift
@@ -36,6 +36,14 @@ struct SettingsView: View {
             }
 
             Section(AppText.transcript) {
+                Picker(AppText.outputMode, selection: liveOutputModeBinding) {
+                    ForEach(LiveOutputMode.allCases) { mode in
+                        Text(mode.title).tag(mode)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .disabled(session.isRunning)
+
                 Picker(AppText.sessionLength, selection: $session.sessionDurationMode) {
                     ForEach(SessionDurationMode.allCases) { mode in
                         Text(mode.title).tag(mode)
@@ -114,6 +122,17 @@ struct SettingsView: View {
         .formStyle(.grouped)
         .frame(width: 420)
         .padding()
+    }
+
+    private var liveOutputModeBinding: Binding<LiveOutputMode> {
+        Binding(
+            get: {
+                session.liveOutputMode
+            },
+            set: { mode in
+                session.useLiveOutputMode(mode)
+            }
+        )
     }
 }
 

--- a/Sources/AirTranslate/Views/SidebarView.swift
+++ b/Sources/AirTranslate/Views/SidebarView.swift
@@ -84,13 +84,18 @@ struct SidebarView: View {
 
     private var sessionCard: some View {
         SidebarCard(
-            title: AppText.translationSettings,
+            title: session.isTranscribeOnlyMode ? AppText.transcriptionSettings : AppText.translationSettings,
             headerAccessory: {
                 openConfigurationButton
             }
         ) {
             VStack(spacing: 10) {
                 languageControls
+
+                LiveOutputModePicker(
+                    selection: liveOutputModeBinding,
+                    isDisabled: session.isRunning
+                )
 
                 ProcessingEnginePicker(
                     selection: processingEngineBinding,
@@ -127,7 +132,9 @@ struct SidebarView: View {
 
     @ViewBuilder
     private var languageControls: some View {
-        if usesOpenAIAutoLanguageFlow {
+        if session.isTranscribeOnlyMode {
+            transcriptionLanguageControls
+        } else if usesOpenAIAutoLanguageFlow {
             VStack(alignment: .leading, spacing: 6) {
                 AutoLanguageRow(helpText: AppText.openAILanguageModeDescription)
                 PreferredLanguageRow(
@@ -184,6 +191,17 @@ struct SidebarView: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
         }
+    }
+
+    private var transcriptionLanguageControls: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 6) {
+                CompactLanguagePicker(title: AppText.from, selection: $session.sourceLanguage)
+                Spacer(minLength: 0)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private var appleSourceAutoDetectionBinding: Binding<Bool> {
@@ -243,6 +261,17 @@ struct SidebarView: View {
                         isConfigurationPresented = true
                     }
                 }
+            }
+        )
+    }
+
+    private var liveOutputModeBinding: Binding<LiveOutputMode> {
+        Binding(
+            get: {
+                session.liveOutputMode
+            },
+            set: { mode in
+                session.useLiveOutputMode(mode)
             }
         )
     }
@@ -418,7 +447,12 @@ private struct ConfigurationSheetView: View {
             VStack(spacing: 6) {
                 ForEach(IntelligenceModel.allCases) { model in
                     Button {
-                        session.selectedModel = model
+                        switch model {
+                        case .appleSpeechOnly:
+                            session.useTranscribeOnlyMode()
+                        case .appleSystem, .appleOnDevice:
+                            session.useTranslationMode()
+                        }
                     } label: {
                         ModelModeRow(
                             model: model,

--- a/Tests/AirTranslateCoreTests/TranslationSessionStoreLanguageCandidateTests.swift
+++ b/Tests/AirTranslateCoreTests/TranslationSessionStoreLanguageCandidateTests.swift
@@ -140,4 +140,16 @@ struct TranslationSessionStoreLanguageCandidateTests {
         #expect(line.sourceDisplayText.hasPrefix("..."))
         #expect(line.translatedDisplayText.hasPrefix("..."))
     }
+
+    @Test
+    @MainActor
+    func transcribeOnlyModeHidesTranslationPane() {
+        let session = TranslationSessionStore()
+
+        session.selectedModel = .appleSpeechOnly
+        #expect(!session.shouldShowTranslationPane)
+
+        session.selectedModel = .appleSystem
+        #expect(session.shouldShowTranslationPane)
+    }
 }

--- a/Tests/AirTranslateCoreTests/TranslationSessionStoreLanguageCandidateTests.swift
+++ b/Tests/AirTranslateCoreTests/TranslationSessionStoreLanguageCandidateTests.swift
@@ -152,4 +152,45 @@ struct TranslationSessionStoreLanguageCandidateTests {
         session.selectedModel = .appleSystem
         #expect(session.shouldShowTranslationPane)
     }
+
+    @Test
+    @MainActor
+    func sameLanguagePairSwitchesToTranscribeOnlyMode() {
+        let session = TranslationSessionStore()
+
+        session.sourceLanguage = LanguageOption.english
+        session.targetLanguage = LanguageOption.english
+
+        #expect(session.liveOutputMode == .transcription)
+        #expect(!session.shouldShowTranslationPane)
+    }
+
+    @Test
+    @MainActor
+    func differentLanguagePairRestoresTranslationModeFromTranscribeOnly() {
+        let session = TranslationSessionStore()
+
+        session.sourceLanguage = LanguageOption.english
+        session.useTranscribeOnlyMode()
+        session.targetLanguage = LanguageOption.supported[2]
+
+        #expect(session.liveOutputMode == .translation)
+        #expect(session.shouldShowTranslationPane)
+    }
+
+    @Test
+    @MainActor
+    func transcribeOnlyModeUsesOriginalOnlyFloatingCaptionsAndRestoresPreviousMode() {
+        let session = TranslationSessionStore()
+
+        session.floatingCaptionDisplayMode = .originalAndTranslation
+        #expect(session.floatingCaptionDisplayMode == .originalAndTranslation)
+
+        session.useTranscribeOnlyMode()
+        #expect(session.floatingCaptionDisplayMode == .original)
+        #expect(session.floatingNoticeText == nil)
+
+        session.useTranslationMode()
+        #expect(session.floatingCaptionDisplayMode == .originalAndTranslation)
+    }
 }

--- a/Tests/AirTranslateCoreTests/TranslationSessionStoreLanguageCandidateTests.swift
+++ b/Tests/AirTranslateCoreTests/TranslationSessionStoreLanguageCandidateTests.swift
@@ -167,12 +167,29 @@ struct TranslationSessionStoreLanguageCandidateTests {
 
     @Test
     @MainActor
-    func differentLanguagePairRestoresTranslationModeFromTranscribeOnly() {
+    func manualTranscribeOnlyModePersistsAcrossLanguageChanges() {
         let session = TranslationSessionStore()
 
         session.sourceLanguage = LanguageOption.english
+        session.targetLanguage = LanguageOption.korean
         session.useTranscribeOnlyMode()
-        session.targetLanguage = LanguageOption.supported[2]
+        session.sourceLanguage = LanguageOption.supported[2]
+
+        #expect(session.liveOutputMode == .transcription)
+        #expect(!session.shouldShowTranslationPane)
+    }
+
+    @Test
+    @MainActor
+    func sameLanguageAutoTranscribeOnlyRestoresTranslationWhenPairDiffers() {
+        let session = TranslationSessionStore()
+
+        session.sourceLanguage = LanguageOption.english
+        session.targetLanguage = LanguageOption.english
+
+        #expect(session.liveOutputMode == .transcription)
+
+        session.targetLanguage = LanguageOption.korean
 
         #expect(session.liveOutputMode == .translation)
         #expect(session.shouldShowTranslationPane)


### PR DESCRIPTION
## Summary
- Show only the original transcript pane when Transcribe Only mode is selected.
- Add an Output Mode switch so the sidebar/settings reflect Translation vs Transcribe Only mode.
- Keep Transcribe Only selected when the user changes languages manually.
- Preserve the same-language convenience: source == target auto-switches to Transcribe Only, and only that auto-selected state restores Translation when the pair differs again.
- Keep floating captions original-only in Transcribe Only and show the one-shot notice for about 10 seconds.

## Verification
- Frontend employee pre-implementation verification: confirmed the language-change reset bug and root cause in `syncLiveOutputModeWithLanguagePair()`.
- Frontend employee post-implementation verification: PASS for manual Transcribe Only persistence, same-language auto restore, SwiftUI binding safety, and regression-test coverage.
- `swift build`: pass.
- `git diff --check`: pass.
- `swift test`: blocked locally because this Command Line Tools environment cannot import Swift Testing's `Testing` module (`no such module Testing`).
- Computer Use: verified the installed `/Applications/AirTranslate.app` opens with Transcription Settings, Output Mode, From-only language controls, and Transcribe English workspace in Transcribe Only mode.

## Notes
This PR now covers the full Transcribe Only UI/state flow: single-pane transcript display, mode controls, floating caption behavior, and language-change persistence.