### PR TITLE
fix: scale floating caption wrapping by text size

### DIFF
--- a/Sources/AirTranslate/Models/FloatingCaptionTextSize.swift
+++ b/Sources/AirTranslate/Models/FloatingCaptionTextSize.swift
@@ -37,6 +37,19 @@ enum FloatingCaptionTextSize: String, CaseIterable, Identifiable {
         secondaryPointSize * 1.28
     }
 
+    var floatingLineWidthUnits: Double {
+        switch self {
+        case .small:
+            39
+        case .medium:
+            32
+        case .large:
+            25
+        case .extraLarge:
+            20
+        }
+    }
+
     private var primaryPointSize: CGFloat {
         switch self {
         case .small:

--- a/Sources/AirTranslate/Services/TranslationSessionStore.swift
+++ b/Sources/AirTranslate/Services/TranslationSessionStore.swift
@@ -1040,7 +1040,10 @@ final class TranslationSessionStore {
     private func floatingCaptionText(from text: String?) -> String {
         guard let text else { return "" }
 
-        return text.floatingCaptionTail(maxLines: floatingCaptionLineCount.rawValue)
+        return text.floatingCaptionTail(
+            maxLines: floatingCaptionLineCount.rawValue,
+            lineWidthUnits: floatingCaptionTextSize.floatingLineWidthUnits
+        )
     }
 
     private func loadSavedTranscripts() {

--- a/Sources/AirTranslate/Support/FloatingCaptionTextFormatter.swift
+++ b/Sources/AirTranslate/Support/FloatingCaptionTextFormatter.swift
@@ -1,8 +1,7 @@
 import Foundation
 
 private enum FloatingCaptionTextLayout {
-    // Approximate readable caption width: about 63 ASCII chars or 39 CJK chars.
-    static let lineWidthUnits = 39.0
+    static let defaultLineWidthUnits = 32.0
     static let scanLineMultiplier = 4
 
     static func displayWidth(of character: Character) -> Double {
@@ -19,8 +18,12 @@ private enum FloatingCaptionTextLayout {
 }
 
 extension String {
-    func floatingCaptionTail(maxLines: Int) -> String {
+    func floatingCaptionTail(
+        maxLines: Int,
+        lineWidthUnits: Double = FloatingCaptionTextLayout.defaultLineWidthUnits
+    ) -> String {
         let maxLines = max(1, maxLines)
+        let lineWidthUnits = max(1, lineWidthUnits)
         let trimmedText = trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedText.isEmpty else { return "" }
         let scanCharacters = maxLines * 72 * FloatingCaptionTextLayout.scanLineMultiplier
@@ -28,7 +31,7 @@ extension String {
         let scanText = String(captionText.boundedSuffix(maxCharacters: scanCharacters))
 
         let logicalLines = scanText.floatingCaptionWrappedLines(
-            maxLineWidth: FloatingCaptionTextLayout.lineWidthUnits
+            maxLineWidth: lineWidthUnits
         )
 
         return logicalLines

--- a/Tests/AirTranslateCoreTests/FloatingCaptionTextFormatterTests.swift
+++ b/Tests/AirTranslateCoreTests/FloatingCaptionTextFormatterTests.swift
@@ -19,16 +19,35 @@ struct FloatingCaptionTextFormatterTests {
 
     @Test
     func floatingCaptionTailKeepsMediumEnglishCaptionOnOneLine() {
-        let text = "This caption should stay on one line with the wider threshold."
+        let text = "Why you think we running up for truth hurts, homie."
 
-        let caption = text.floatingCaptionTail(maxLines: 2)
+        let caption = text.floatingCaptionTail(
+            maxLines: 2,
+            lineWidthUnits: FloatingCaptionTextSize.medium.floatingLineWidthUnits
+        )
 
         #expect(caption == text)
     }
 
     @Test
+    func floatingCaptionTailUsesFontSizeWidthBudget() {
+        let text = "Why you think we running up for the truth hurts homie tough love. Tough love keeps the caption readable."
+
+        for size in FloatingCaptionTextSize.allCases {
+            let caption = text.floatingCaptionTail(
+                maxLines: 4,
+                lineWidthUnits: size.floatingLineWidthUnits
+            )
+            let lines = caption.split(separator: "\n", omittingEmptySubsequences: true)
+
+            #expect(!lines.isEmpty)
+            #expect(lines.allSatisfy { $0.floatingCaptionTestDisplayWidth <= size.floatingLineWidthUnits + 0.001 })
+        }
+    }
+
+    @Test
     func floatingCaptionTailWrapsCJKTextWithoutWhitespace() {
-        let text = "감가상각비와이연법인세회계처리를연속해서설명하는강의문장이길어져도자막창에서는읽기좋게나뉘어야합니다"
+        let text = "감가상각비와이연법인세회계처리를연속해서설명하는강의문장이길어져도자막창에서는읽기좋게나뉘어야합니다감가상각비와이연법인세회계처리를연속해서설명하는강의문장이길어져도자막창에서는읽기좋게나뉘어야합니다"
 
         let caption = text.floatingCaptionTail(maxLines: 3)
         let lines = caption.split(separator: "\n", omittingEmptySubsequences: true)
@@ -49,5 +68,21 @@ struct FloatingCaptionTextFormatterTests {
         Second idea follows?
         Third idea lands!
         """)
+    }
+}
+
+private extension Substring {
+    var floatingCaptionTestDisplayWidth: Double {
+        reduce(0) { width, character in
+            if character.isWhitespace {
+                return width + 0.45
+            }
+
+            guard let scalar = character.unicodeScalars.first else {
+                return width + 1
+            }
+
+            return width + (scalar.isASCII ? 0.62 : 1)
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Make floating-caption line wrapping aware of the selected caption text size instead of using one fixed width.
- Add width budgets for small, medium, large, and extra-large floating caption text.
- Pass the current `floatingCaptionTextSize` budget through `TranslationSessionStore` into `floatingCaptionTail`.
- Add formatter tests for medium one-line fitting and all text sizes respecting their width budget.

## Verification
- Frontend employee post-implementation verification: PASS.
- `swift build`: pass.
- `git diff --check`: pass.
- `swift test --filter FloatingCaptionTextFormatterTests`: blocked locally because this Command Line Tools environment cannot import Swift Testing's `Testing` module (`no such module Testing`).
- Local combined release app and patched DMG were rebuilt and installed at `/Applications/AirTranslate.app` and `/Users/jun/Downloads/AirTranslate-1.3.1-patched-20260526.dmg`.

## Context
PR #4 was already merged, so this is a follow-up PR for the regression where a wider fixed formatter line made larger floating-caption font sizes show less usable text because SwiftUI lineLimit clips visual lines, not formatter logical lines.