### PR TITLE
Release AirTranslate 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to AirTranslate are documented in this file.
 
 No unreleased changes yet.
 
+## 1.4.1 - 2026-07-24
+
+### Changed
+
+- Translated speech output in Apple mode now waits for stable sentence boundaries during streaming and still speaks final translation text that arrives without punctuation.
+- Dubbing progress is now tracked by a focused core helper so speech-output replay behavior can be tested independently from the main session store.
+
+### Fixed
+
+- Fixed Apple-mode translated speech repeating restored sentence tails after shorter streaming rewrites.
+- Fixed translated speech replaying near-duplicate finalization variants or rereading text that was already visible when dubbing was enabled.
+- Fixed short repeated suffixes such as repeated closing words being spoken again while still allowing legitimate repeated phrases later in the session.
+
 ## 1.4.0 - 2026-07-10
 
 ### Added

--- a/README.ja.md
+++ b/README.ja.md
@@ -47,16 +47,16 @@ AirTranslateは、Macで再生されている音声をリアルタイムで文�
 
 > "Turn any Mac audio into live captions and translation, right where you are watching."
 
-## 1.4.0の主な変更点
+## 1.4.1の主な変更点
 
-- **長時間セッションの応答性:** Apple標準モードは非常に長い記録の更新を自動的にまとめ、大きな翻訳入力の準備をUIメインスレッド外で行い、上限付きLRU翻訳キャッシュを使用します。
-- **安全な記録の継続:** キャプチャ中は30秒ごとに同じ記録ファイルを更新し、一時停止・停止・アプリ終了時には保留中の最後の単語まで保存します。
-- **APIモードの低遅延化:** Gemini Liveは明示的な音声アクティビティ検出と上限付き初期オーディオバッファを使用し、OpenAIテキスト翻訳は部分結果のストリーミング、タイムアウト、再試行を行います。
-- **翻訳音声バックログの制限:** 古いリアルタイム音声や合成音声が字幕から遅れ続けないよう、破棄または再生速度の調整を行います。
-- **明確なmacOS操作:** 聞き取り中・一時停止・保存完了をテキストで示し、`Command-Return`で開始/停止、`Shift-Command-Space`で一時停止/再開できます。
-- **アクセシビリティとウィンドウ安定性:** Reduce Motion、記録領域ラベル、キーボード操作、ディスプレイ変更後のフローティング字幕復元を改善しました。
+- **より安定した翻訳音声:** Apple標準モードは、ストリーミング翻訳文が安定した文境界に到達してから読み上げます。
+- **最後の文も読み上げ:** 句読点なしで届いた最終翻訳も、翻訳リクエスト完了時にすぐ音声出力します。
+- **繰り返し末尾の抑制:** 短く書き換わってから復元された文末、ほぼ同じ確定版、短い重複接尾部分を再度読み上げません。
+- **すっきりした吹き替え切替:** 翻訳音声を有効にしたとき、すでに表示されていた翻訳文を読み直しません。
+- **正当な繰り返しは維持:** 短いリプレイ防止時間を過ぎた実際の繰り返しフレーズは、同じセッション内でも再度読み上げられます。
+- **集中的な回帰テスト:** 翻訳音声の進行ロジックを専用のAirTranslateCoreテストで検証します。
 
-詳細は[AirTranslate 1.4.0リリースノート](https://github.com/himomohi/AirTranslate/releases/tag/v1.4.0)をご覧ください。
+詳細は[AirTranslate 1.4.1リリースノート](https://github.com/himomohi/AirTranslate/releases/tag/v1.4.1)をご覧ください。
 
 ## 主な機能
 
@@ -133,7 +133,7 @@ macOSのプライバシー権限を変更した後は、アプリを終了して
 最新のオープンソースビルドは[GitHub Releases](https://github.com/himomohi/AirTranslate/releases/latest)からダウンロードできます。DMGが最も簡単なインストール方法で、ZIPも軽量な配布形式として引き続き利用できます。
 
 - [AirTranslate.dmgをダウンロード](https://github.com/himomohi/AirTranslate/releases/latest/download/AirTranslate.dmg)
-- [AirTranslate-1.4.0.zipをダウンロード](https://github.com/himomohi/AirTranslate/releases/latest/download/AirTranslate-1.4.0.zip)
+- [AirTranslate-1.4.1.zipをダウンロード](https://github.com/himomohi/AirTranslate/releases/latest/download/AirTranslate-1.4.1.zip)
 - [AirTranslate.dmg.sha256をダウンロード](https://github.com/himomohi/AirTranslate/releases/latest/download/AirTranslate.dmg.sha256)
 - [バージョン履歴を見る](Release/VERSION-HISTORY.md)
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -47,16 +47,16 @@ AirTranslate는 Mac에서 재생되는 소리를 실시간으로 기록하고 �
 
 > "Turn any Mac audio into live captions and translation, right where you are watching."
 
-## 1.4.0 주요 변경사항
+## 1.4.1 주요 변경사항
 
-- **장시간 반응성:** Apple 기본 모드는 매우 긴 기록의 갱신을 자동 병합하고, 큰 번역 입력 준비를 UI 메인 스레드 밖에서 수행하며, 크기가 제한된 LRU 번역 캐시를 사용합니다.
-- **안전한 기록 연속성:** 캡처 중에는 30초마다 같은 기록 파일을 갱신하고, 일시정지·정지·앱 종료 시 대기 중인 마지막 단어까지 저장합니다.
-- **API 모드 지연 개선:** Gemini Live는 명시적 음성 활동 감지와 제한된 초기 오디오 버퍼를 사용하고, OpenAI 텍스트 번역은 부분 결과 스트리밍·제한 시간·재시도를 적용합니다.
-- **번역 음성 backlog 제한:** 오래된 실시간/합성 음성이 자막보다 계속 뒤처지지 않도록 폐기하거나 재생 속도를 조정합니다.
-- **명확한 macOS 조작:** 듣는 중·일시정지·저장 완료 상태를 텍스트로 표시하며, `Command-Return`으로 시작/정지하고 `Shift-Command-Space`로 일시정지/재개할 수 있습니다.
-- **접근성과 창 안정성:** Reduce Motion, 기록 영역 라벨, 키보드 접근, 디스플레이 변경 후 플로팅 자막 복원을 개선했습니다.
+- **더 안정적인 번역 음성:** Apple 기본 모드는 스트리밍 번역문이 안정적인 문장 경계에 도달한 뒤 음성으로 읽습니다.
+- **마지막 문장 보존:** 마침표 없이 끝난 최종 번역도 요청이 완료되면 바로 음성으로 출력합니다.
+- **반복 꼬리 억제:** 짧게 줄었다가 복원된 문장 끝부분, 거의 같은 최종 수정본, 짧은 반복 접미어를 다시 읽지 않습니다.
+- **깔끔한 더빙 전환:** 번역 음성을 켰을 때 이미 화면에 보이던 번역문을 다시 읽지 않습니다.
+- **정상 반복 유지:** 짧은 재생 방지 시간이 지난 뒤 실제로 반복되는 문구는 같은 세션 안에서도 다시 읽을 수 있습니다.
+- **집중 회귀 테스트:** 번역 음성 진행 로직을 전용 AirTranslateCore 테스트로 검증합니다.
 
-전체 내용은 [AirTranslate 1.4.0 릴리즈 노트](https://github.com/himomohi/AirTranslate/releases/tag/v1.4.0)에서 확인할 수 있습니다.
+전체 내용은 [AirTranslate 1.4.1 릴리즈 노트](https://github.com/himomohi/AirTranslate/releases/tag/v1.4.1)에서 확인할 수 있습니다.
 
 ## 핵심 기능
 
@@ -135,7 +135,7 @@ macOS 개인정보 보호 권한을 바꾼 뒤에는 앱을 종료하고 다시 
 AirTranslate는 Apache-2.0 라이선스의 오픈소스 프로젝트입니다. DMG 파일은 macOS 사용자가 더 쉽게 설치할 수 있도록 추가로 제공되는 설치 패키지이며, 소스코드 공개를 대체하는 것이 아닙니다. 소스코드, 빌드 스크립트, 릴리즈 자료, LICENSE, NOTICE 파일은 모두 이 저장소에 공개되어 있습니다.
 
 - [AirTranslate.dmg 다운로드](https://github.com/himomohi/AirTranslate/releases/latest/download/AirTranslate.dmg)
-- [AirTranslate-1.4.0.zip 다운로드](https://github.com/himomohi/AirTranslate/releases/latest/download/AirTranslate-1.4.0.zip)
+- [AirTranslate-1.4.1.zip 다운로드](https://github.com/himomohi/AirTranslate/releases/latest/download/AirTranslate-1.4.1.zip)
 - [AirTranslate.dmg.sha256 다운로드](https://github.com/himomohi/AirTranslate/releases/latest/download/AirTranslate.dmg.sha256)
 - [버전 히스토리 보기](Release/VERSION-HISTORY.md)
 

--- a/README.md
+++ b/README.md
@@ -47,16 +47,16 @@ The default workflow uses Apple frameworks. GPT Realtime and Gemini Live Transla
 
 > "Turn any Mac audio into live captions and translation, right where you are watching."
 
-## What's New in 1.4.0
+## What's New in 1.4.1
 
-- **Long-session responsiveness:** Apple Mode automatically coalesces very large transcript updates, prepares large translation input away from the main UI thread, and uses a bounded LRU translation cache.
-- **Safer transcript continuity:** active sessions update the same transcript checkpoint every 30 seconds, and pending words are flushed on pause, stop, and app termination.
-- **Lower live-provider latency:** Gemini Live uses explicit voice activity detection and bounded pre-setup audio buffering, while OpenAI text translation streams partial results with bounded timeouts and retries.
-- **Bounded translated-audio backlog:** stale realtime or synthesized speech is discarded or accelerated instead of drifting progressively behind the captions.
-- **Clearer macOS controls:** listening, paused, and saved states are explicit; `Command-Return` starts or stops capture, and `Shift-Command-Space` pauses or resumes it.
-- **Accessibility and window stability:** Reduce Motion, transcript-region labels, keyboard access, and floating-caption recovery after display changes are improved.
+- **Steadier translated speech:** Apple Mode now waits for stable sentence boundaries before speaking streaming translated text.
+- **Final text still speaks:** final translations that arrive without punctuation are spoken when the translation request completes.
+- **Fewer repeated tails:** restored sentence tails, near-duplicate finalization variants, and short repeated suffixes are suppressed instead of being spoken again.
+- **Cleaner dubbing handoff:** enabling translated speech no longer rereads translation text that was already visible.
+- **Legitimate repeats preserved:** repeated phrases can still be spoken later in a session after the short replay window expires.
+- **Focused regression coverage:** the translated-speech progress logic is covered by dedicated AirTranslateCore tests.
 
-See the complete [AirTranslate 1.4.0 release notes](https://github.com/himomohi/AirTranslate/releases/tag/v1.4.0).
+See the complete [AirTranslate 1.4.1 release notes](https://github.com/himomohi/AirTranslate/releases/tag/v1.4.1).
 
 ## Core Features
 
@@ -135,7 +135,7 @@ Download the latest open-source build from [GitHub Releases](https://github.com/
 AirTranslate remains fully open-source under the Apache-2.0 License. The DMG is provided only as a convenient macOS installer, while all source code, build scripts, release materials, LICENSE, and NOTICE files remain available in this repository.
 
 - [Download AirTranslate.dmg](https://github.com/himomohi/AirTranslate/releases/latest/download/AirTranslate.dmg)
-- [Download AirTranslate-1.4.0.zip](https://github.com/himomohi/AirTranslate/releases/latest/download/AirTranslate-1.4.0.zip)
+- [Download AirTranslate-1.4.1.zip](https://github.com/himomohi/AirTranslate/releases/latest/download/AirTranslate-1.4.1.zip)
 - [Download AirTranslate.dmg.sha256](https://github.com/himomohi/AirTranslate/releases/latest/download/AirTranslate.dmg.sha256)
 - [View version history](Release/VERSION-HISTORY.md)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -47,16 +47,16 @@ AirTranslate 可以捕获 Mac 正在播放的音频，实时转写并翻译，�
 
 > "Turn any Mac audio into live captions and translation, right where you are watching."
 
-## 1.4.0 主要更新
+## 1.4.1 主要更新
 
-- **长时间运行响应性:** Apple 默认模式会自动合并超长记录更新，在 UI 主线程之外准备大型翻译输入，并使用容量受限的 LRU 翻译缓存。
-- **更安全的记录连续性:** 捕获期间每30秒更新同一组记录文件，并在暂停、停止或退出应用时保存仍在等待的最后内容。
-- **降低 API 模式延迟:** Gemini Live 使用明确的语音活动检测和受限的连接前音频缓冲；OpenAI 文本翻译支持部分结果流式返回、超时和重试。
-- **限制译文语音积压:** 过时的实时或合成语音会被丢弃或加速，避免持续落后于字幕。
-- **更清晰的 macOS 操作:** 以文字显示正在聆听、已暂停和已保存状态；`Command-Return` 用于开始/停止，`Shift-Command-Space` 用于暂停/继续。
-- **辅助功能与窗口稳定性:** 改进 Reduce Motion、记录区域标签、键盘操作，以及显示器变化后的悬浮字幕窗口恢复。
+- **更稳定的译文语音:** Apple 默认模式会等流式译文到达稳定句子边界后再朗读。
+- **最终文本仍会朗读:** 没有标点的最终译文会在翻译请求完成时立即语音输出。
+- **减少重复尾句:** 短暂改写后恢复的句尾、近似重复的最终修订，以及短重复后缀不会再次朗读。
+- **更干净的配音切换:** 启用译文语音时，不会重新朗读已经显示在屏幕上的译文。
+- **保留合理重复:** 短暂防重放窗口过后，真实重复出现的短语仍可在同一会话中再次朗读。
+- **聚焦回归测试:** 译文语音进度逻辑由专门的 AirTranslateCore 测试覆盖。
 
-完整内容请参阅 [AirTranslate 1.4.0 发布说明](https://github.com/himomohi/AirTranslate/releases/tag/v1.4.0)。
+完整内容请参阅 [AirTranslate 1.4.1 发布说明](https://github.com/himomohi/AirTranslate/releases/tag/v1.4.1)。
 
 ## 核心功能
 
@@ -133,7 +133,7 @@ AirTranslate 只请求捕获和转写流程需要的权限。
 最新开源构建可在 [GitHub Releases](https://github.com/himomohi/AirTranslate/releases/latest) 下载。DMG 是最简单的安装路径，ZIP 也会继续作为轻量压缩包提供。
 
 - [下载 AirTranslate.dmg](https://github.com/himomohi/AirTranslate/releases/latest/download/AirTranslate.dmg)
-- [下载 AirTranslate-1.4.0.zip](https://github.com/himomohi/AirTranslate/releases/latest/download/AirTranslate-1.4.0.zip)
+- [下载 AirTranslate-1.4.1.zip](https://github.com/himomohi/AirTranslate/releases/latest/download/AirTranslate-1.4.1.zip)
 - [下载 AirTranslate.dmg.sha256](https://github.com/himomohi/AirTranslate/releases/latest/download/AirTranslate.dmg.sha256)
 - [查看版本历史](Release/VERSION-HISTORY.md)
 

--- a/Release/GITHUB-RELEASE-1.4.1.md
+++ b/Release/GITHUB-RELEASE-1.4.1.md
@@ -1,0 +1,45 @@
+# AirTranslate 1.4.1
+
+Translated-speech replay fixes for Apple mode dubbing.
+
+AirTranslate is an independent open-source project and is not affiliated with Apple, OpenAI, or Google.
+
+## Changed
+
+- Apple-mode translated speech now waits for stable sentence boundaries during streaming before speaking a partial translation.
+- Final translation text that arrives without punctuation still speaks immediately when the request completes.
+- Dubbing speech progress is now covered by focused AirTranslateCore regression tests.
+
+## Fixed
+
+- Fixed translated speech repeating the tail of a restored sentence after a shorter streaming rewrite.
+- Fixed near-duplicate finalization variants being spoken again.
+- Fixed translated speech rereading text that was already visible when dubbing was enabled.
+- Fixed short suffix replays while preserving legitimate later repeated phrases in the same session.
+
+## Verification
+
+- 132 automated tests across 16 suites passed with the repository's Xcode toolchain.
+- Release-prep checks completed locally: `swift build -c release`, `./script/build_and_run.sh --verify`, `./Release/build_open_source_release.sh all`, update-set audit, DMG verification, checksum validation, app metadata inspection, code signature integrity, and source/artifact secret scans.
+
+## Download
+
+- For most users: Download `AirTranslate.dmg`, open it, and drag `AirTranslate.app` to Applications.
+- For ZIP users: Download `AirTranslate-1.4.1.zip`.
+- Versioned DMG assets are also attached as `AirTranslate-1.4.1.dmg` and `AirTranslate-1.4.1.dmg.sha256`.
+
+## GitHub Links
+
+- Repository: https://github.com/himomohi/AirTranslate
+- AirTranslate 1.4.1 release: https://github.com/himomohi/AirTranslate/releases/tag/v1.4.1
+- Latest DMG download: https://github.com/himomohi/AirTranslate/releases/latest/download/AirTranslate.dmg
+
+## Distribution Notes
+
+AirTranslate remains fully open-source under the Apache-2.0 License.
+
+This build uses an ad-hoc code signature and is not Apple-notarized. macOS may show an unidentified-developer warning on first launch. If that happens, Control-click or right-click `AirTranslate.app`, choose **Open**, then confirm **Open**.
+
+You can verify the stable DMG with `AirTranslate.dmg.sha256`.
+
+Older GitHub Releases remain available for users who need a previous version.

--- a/Release/README.md
+++ b/Release/README.md
@@ -13,7 +13,7 @@ This folder contains reproducible release materials for the Apache 2.0 open-sour
 
 - The app name remains `AirTranslate`.
 - The bundle identifier is `dev.appcaster.AirTranslate`.
-- The current release-candidate version is `1.4.0`.
+- The current release-candidate version is `1.4.1`.
 - The project is published as Apache 2.0 open source.
 - AirTranslate is an independent project and is not affiliated with Apple, OpenAI, or Google.
 - The release bundle must never include user API keys, bearer tokens, signing private keys, provisioning profiles, or local `.env` files.
@@ -21,7 +21,7 @@ This folder contains reproducible release materials for the Apache 2.0 open-sour
 Override the defaults when needed:
 
 ```bash
-BUNDLE_ID="com.example.AirTranslate" VERSION="1.4.0" BUILD_NUMBER="140"
+BUNDLE_ID="com.example.AirTranslate" VERSION="1.4.1" BUILD_NUMBER="141"
 ```
 
 ## Local Release Build

--- a/Release/VERSION-HISTORY.md
+++ b/Release/VERSION-HISTORY.md
@@ -1,5 +1,18 @@
 # AirTranslate Version History
 
+## 1.4.1 - 2026-07-24
+
+### Changed
+
+- Apple-mode translated speech now waits for stable sentence boundaries during streaming and speaks final unpunctuated translations immediately when the request completes.
+- Dubbing speech progress is isolated in AirTranslateCore with focused regression coverage for streaming rewrites, finalization revisions, suffix replays, priming, and repeat expiry.
+
+### Fixed
+
+- Prevented translated speech from repeating the tail of a restored sentence after a shorter streaming rewrite.
+- Suppressed near-duplicate finalization variants and text that was already visible before dubbing was enabled.
+- Prevented short suffix replays while keeping legitimate later repeated phrases speakable.
+
 ## 1.4.0 - 2026-07-10
 
 ### Added

--- a/Sources/AirTranslate/Services/TranslationSessionStore.swift
+++ b/Sources/AirTranslate/Services/TranslationSessionStore.swift
@@ -118,8 +118,7 @@ final class TranslationSessionStore {
                 }
             } else {
                 stopSpeaking()
-                lastSpokenTranslatedText = ""
-                clearSpokenTranslationUnits()
+                dubbingSpeechProgress.reset()
             }
         }
     }
@@ -340,9 +339,7 @@ final class TranslationSessionStore {
     private var transcribeOnlyNoticeDismissTask: Task<Void, Never>?
     private var captureStartTask: Task<Void, Never>?
     private var captureStopTask: Task<Void, Never>?
-    private var lastSpokenTranslatedText = ""
-    private var spokenTranslationUnitKeys: Set<String> = []
-    private var spokenTranslationUnitKeyOrder: [String] = []
+    private var dubbingSpeechProgress = DubbingSpeechProgress()
     private var hasShownTranscribeOnlyNoticeForCurrentActivation = false
     private var floatingCaptionDisplayModeBeforeTranscribeOnly: FloatingCaptionDisplayMode?
     private var appleVoiceOutputEnabled = false
@@ -1422,8 +1419,7 @@ final class TranslationSessionStore {
         transcriptCheckpointTask?.cancel()
         transcriptCheckpointTask = nil
         stopSpeaking()
-        lastSpokenTranslatedText = ""
-        clearSpokenTranslationUnits()
+        dubbingSpeechProgress.reset()
         translationTask?.cancel()
         translationTask = nil
         transcriptCleanupTask?.cancel()
@@ -3499,7 +3495,7 @@ final class TranslationSessionStore {
         )
 
         updateFloatingTranslationPresentation(floatingTranslatedText, sourceText: sourceText)
-        speakTranslatedDeltaIfNeeded(organizedTranslatedText)
+        speakTranslatedDeltaIfNeeded(organizedTranslatedText, isFinal: finalizesRequest)
     }
 
     private func markTranslationUnavailable(_ message: String, for line: CaptionLine, matching sourceText: String) {
@@ -3649,51 +3645,18 @@ final class TranslationSessionStore {
         speechOutput.speak(text, language: targetLanguage)
     }
 
-    private func speakTranslatedDeltaIfNeeded(_ translatedText: String) {
+    private func speakTranslatedDeltaIfNeeded(_ translatedText: String, isFinal: Bool = false) {
         guard isRunning, !isPaused, isDubbingEnabled else { return }
         guard !isUsingProviderRealtimeTranslation else { return }
+        guard translatedText != AppText.translating else { return }
 
-        let currentText = speechReadyText(translatedText)
-        guard !currentText.isEmpty else { return }
+        guard let unspokenText = dubbingSpeechProgress.unspokenText(
+            from: translatedText,
+            languageID: targetLanguage.id,
+            isFinal: isFinal
+        ) else { return }
 
-        let previousText = lastSpokenTranslatedText
-        lastSpokenTranslatedText = currentText
-
-        guard let delta = speechDelta(previous: previousText, current: currentText),
-              let unspokenDelta = unspokenSpeechText(from: delta)
-        else {
-            return
-        }
-
-        speak(unspokenDelta)
-    }
-
-    private func speechReadyText(_ text: String) -> String {
-        guard text != AppText.translating else { return "" }
-
-        return text
-            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    private func speechDelta(previous: String, current: String) -> String? {
-        guard previous != current else { return nil }
-        guard !current.isEmpty else { return nil }
-
-        if previous.isEmpty {
-            return current
-        }
-
-        if current.hasPrefix(previous) {
-            return speakableText(String(current.dropFirst(previous.count)))
-        }
-
-        let sharedPrefixLength = commonPrefixLength(previous, current)
-        if sharedPrefixLength > previous.count / 2 {
-            return speakableText(String(current.dropFirst(sharedPrefixLength)))
-        }
-
-        return nil
+        speak(unspokenText)
     }
 
     private func commonPrefixLength(_ lhs: String, _ rhs: String) -> Int {
@@ -3705,108 +3668,16 @@ final class TranslationSessionStore {
         return length
     }
 
-    private func speakableText(_ text: String) -> String? {
-        let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard trimmedText.rangeOfCharacter(from: .letters.union(.decimalDigits)) != nil else {
-            return nil
-        }
-        return trimmedText
-    }
-
-    private func unspokenSpeechText(from text: String) -> String? {
-        let units = speechUnits(from: text)
-        guard !units.isEmpty else { return nil }
-
-        var unspokenUnits: [String] = []
-        for unit in units {
-            let key = normalizedSpeechUnitKey(unit)
-            guard !key.isEmpty, !spokenTranslationUnitKeys.contains(key) else {
-                continue
-            }
-
-            rememberSpokenTranslationUnitKey(key)
-            unspokenUnits.append(unit)
-        }
-
-        guard !unspokenUnits.isEmpty else { return nil }
-        return unspokenUnits.joined(separator: " ")
-    }
-
-    private func speechUnits(from text: String) -> [String] {
-        var units: [String] = []
-        var currentUnit = ""
-        let terminators = CharacterSet(charactersIn: ".!?。！？\n")
-
-        for scalar in text.unicodeScalars {
-            currentUnit.unicodeScalars.append(scalar)
-            if terminators.contains(scalar) {
-                let unit = speechReadyText(currentUnit)
-                if !unit.isEmpty {
-                    units.append(unit)
-                }
-                currentUnit = ""
-            }
-        }
-
-        let remainingUnit = speechReadyText(currentUnit)
-        if !remainingUnit.isEmpty {
-            units.append(remainingUnit)
-        }
-
-        return units
-    }
-
-    private func normalizedSpeechUnitKey(_ text: String) -> String {
-        let foldedText = text.folding(options: [.caseInsensitive, .diacriticInsensitive], locale: targetLanguage.locale)
-        let allowedCharacters = CharacterSet.letters
-            .union(.decimalDigits)
-            .union(.whitespacesAndNewlines)
-        let filteredText = String(foldedText.unicodeScalars.map { scalar in
-            allowedCharacters.contains(scalar) ? Character(scalar) : " "
-        })
-
-        return filteredText
-            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    private func rememberSpokenTranslationUnitKey(_ key: String) {
-        spokenTranslationUnitKeys.insert(key)
-        spokenTranslationUnitKeyOrder.append(key)
-
-        while spokenTranslationUnitKeyOrder.count > 160 {
-            let removedKey = spokenTranslationUnitKeyOrder.removeFirst()
-            if !spokenTranslationUnitKeyOrder.contains(removedKey) {
-                spokenTranslationUnitKeys.remove(removedKey)
-            }
-        }
-    }
-
-    private func rememberSpokenTranslationUnits(in text: String) {
-        for unit in speechUnits(from: text) {
-            let key = normalizedSpeechUnitKey(unit)
-            if !key.isEmpty {
-                rememberSpokenTranslationUnitKey(key)
-            }
-        }
-    }
-
-    private func clearSpokenTranslationUnits() {
-        spokenTranslationUnitKeys.removeAll()
-        spokenTranslationUnitKeyOrder.removeAll()
-    }
-
     private func resetDubbingProgress() {
-        lastSpokenTranslatedText = ""
-        clearSpokenTranslationUnits()
+        dubbingSpeechProgress.reset()
         stopSpeaking()
     }
 
     private func primeDubbingBaselineToCurrentTranslation() {
-        let currentTranslation = speechReadyText(lines.last?.translatedText ?? "")
-        lastSpokenTranslatedText = currentTranslation
-        clearSpokenTranslationUnits()
-        rememberSpokenTranslationUnits(in: currentTranslation)
+        dubbingSpeechProgress.prime(
+            with: lines.last?.translatedText ?? "",
+            languageID: targetLanguage.id
+        )
     }
 
     private func stopSpeaking() {

--- a/Sources/AirTranslateCore/DubbingSpeechProgress.swift
+++ b/Sources/AirTranslateCore/DubbingSpeechProgress.swift
@@ -1,0 +1,389 @@
+import Foundation
+
+package struct DubbingSpeechProgress {
+    private struct PendingStreamingUnit {
+        let key: String
+        let text: String
+        let firstSeenAt: Date
+    }
+
+    private struct SpeechUnit {
+        let text: String
+        let isTerminated: Bool
+    }
+
+    private static let maximumRememberedSpeechUnits = 160
+    private static let rememberedSpeechUnitTTL: TimeInterval = 45
+    private static let minimumStreamingSpeechDwell: TimeInterval = 0.9
+    private static let nearDuplicateThreshold = 0.72
+
+    private let now: () -> Date
+    private var lastSpokenText = ""
+    private var spokenUnitKeys: Set<String> = []
+    private var spokenUnitKeyOrder: [(key: String, rememberedAt: Date)] = []
+    private var pendingStreamingUnit: PendingStreamingUnit?
+
+    package init(now: @escaping () -> Date = Date.init) {
+        self.now = now
+    }
+
+    package mutating func reset() {
+        lastSpokenText = ""
+        spokenUnitKeys.removeAll()
+        spokenUnitKeyOrder.removeAll()
+        pendingStreamingUnit = nil
+    }
+
+    package mutating func prime(with translatedText: String, languageID: String) {
+        let currentText = Self.speechReadyText(translatedText)
+        lastSpokenText = currentText
+        spokenUnitKeys.removeAll()
+        spokenUnitKeyOrder.removeAll()
+        pendingStreamingUnit = nil
+        rememberSpokenUnits(in: currentText, languageID: languageID, at: now())
+    }
+
+    package mutating func unspokenText(
+        from translatedText: String,
+        languageID: String,
+        isFinal: Bool = false
+    ) -> String? {
+        let currentTime = now()
+        expireSpokenUnits(at: currentTime)
+
+        let currentText = Self.speechReadyText(translatedText)
+        guard !currentText.isEmpty else { return nil }
+
+        let previousText = lastSpokenText
+        let previousKey = Self.normalizedSpeechUnitKey(previousText, languageID: languageID)
+        if wasRecentlySpoken(previousKey), Self.isNearDuplicateRevision(
+            previous: previousText,
+            current: currentText,
+            languageID: languageID
+        ) {
+            lastSpokenText = currentText
+            pendingStreamingUnit = nil
+            rememberSpokenUnits(in: currentText, languageID: languageID, at: currentTime)
+            return nil
+        }
+
+        if previousText == currentText,
+           let pendingStreamingUnit,
+           pendingStreamingUnit.key == Self.normalizedSpeechUnitKey(currentText, languageID: languageID),
+           currentTime.timeIntervalSince(pendingStreamingUnit.firstSeenAt)
+                >= Self.minimumStreamingSpeechDwell,
+           !wasRecentlySpoken(pendingStreamingUnit.key) {
+            self.pendingStreamingUnit = nil
+            rememberSpokenUnitKey(pendingStreamingUnit.key, at: currentTime)
+            return pendingStreamingUnit.text
+        }
+
+        guard let delta = Self.speechDelta(previous: previousText, current: currentText) else {
+            if Self.shouldAdoptSilentBaselineRevision(
+                previous: previousText,
+                current: currentText,
+                languageID: languageID
+            ) {
+                lastSpokenText = currentText
+                pendingStreamingUnit = nil
+                rememberSpokenUnits(in: currentText, languageID: languageID, at: currentTime)
+            }
+            return nil
+        }
+
+        let decision = unspokenSpeechText(
+            from: delta,
+            languageID: languageID,
+            isFinal: isFinal,
+            at: currentTime
+        )
+        guard let unspokenDelta = decision.text else {
+            if !decision.hasDeferredUnterminatedUnit,
+               Self.shouldAdoptCoveredDeltaBaseline(previous: previousText, current: currentText) {
+                lastSpokenText = currentText
+                rememberSpokenUnits(in: currentText, languageID: languageID, at: currentTime)
+            }
+            return nil
+        }
+
+        if !decision.hasDeferredUnterminatedUnit {
+            lastSpokenText = currentText
+        }
+        return unspokenDelta
+    }
+
+    private static func speechReadyText(_ text: String) -> String {
+        text
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func speechDelta(previous: String, current: String) -> String? {
+        guard previous != current else { return nil }
+        guard !current.isEmpty else { return nil }
+
+        if previous.isEmpty {
+            return current
+        }
+
+        if current.hasPrefix(previous) {
+            return speakableText(String(current.dropFirst(previous.count)))
+        }
+
+        let sharedPrefixLength = commonPrefixLength(previous, current)
+        if sharedPrefixLength > previous.count / 2 {
+            return speakableText(String(current.dropFirst(sharedPrefixLength)))
+        }
+
+        return nil
+    }
+
+    private static func speakableText(_ text: String) -> String? {
+        let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmedText.rangeOfCharacter(from: .letters.union(.decimalDigits)) != nil else {
+            return nil
+        }
+        return trimmedText
+    }
+
+    private static func shouldAdoptSilentBaselineRevision(
+        previous: String,
+        current: String,
+        languageID: String
+    ) -> Bool {
+        guard !previous.isEmpty, !current.isEmpty else { return false }
+
+        let normalizedPrevious = TranscriptTextProcessor.normalizedForComparison(previous)
+        let normalizedCurrent = TranscriptTextProcessor.normalizedForComparison(current)
+        guard normalizedPrevious != normalizedCurrent else { return false }
+
+        if TranscriptTextProcessor.isWholeTextPrefix(normalizedCurrent, of: normalizedPrevious)
+            || TranscriptTextProcessor.isPrefixEndingInsideToken(normalizedCurrent, of: normalizedPrevious) {
+            return false
+        }
+
+        if normalizedSpeechUnitKey(previous, languageID: languageID)
+            == normalizedSpeechUnitKey(current, languageID: languageID) {
+            return true
+        }
+
+        return TranscriptTextProcessor.isLikelyRecentTranscriptRevision(
+            current,
+            of: previous,
+            allowsExactRepeat: false
+        )
+    }
+
+    private static func shouldAdoptCoveredDeltaBaseline(previous: String, current: String) -> Bool {
+        guard !previous.isEmpty else { return true }
+        guard !current.isEmpty else { return false }
+
+        return current.hasPrefix(previous)
+    }
+
+    private mutating func unspokenSpeechText(
+        from text: String,
+        languageID: String,
+        isFinal: Bool,
+        at currentTime: Date
+    ) -> (text: String?, hasDeferredUnterminatedUnit: Bool) {
+        let units = Self.speechUnits(from: text)
+        guard !units.isEmpty else { return (nil, false) }
+
+        var hasDeferredUnterminatedUnit = false
+        var unspokenUnits: [String] = []
+        for unit in units {
+            let key = Self.normalizedSpeechUnitKey(unit.text, languageID: languageID)
+            guard !key.isEmpty else { continue }
+
+            if !isFinal, !unit.isTerminated {
+                hasDeferredUnterminatedUnit = true
+                continue
+            }
+
+            if !isFinal, !canSpeakStreamingUnit(unit, key: key, at: currentTime) {
+                hasDeferredUnterminatedUnit = true
+                continue
+            }
+
+            guard !wasRecentlySpoken(key),
+                  !isRecentlySpokenSuffixReplay(key)
+            else {
+                continue
+            }
+
+            pendingStreamingUnit = nil
+            rememberSpokenUnitKey(key, at: currentTime)
+            unspokenUnits.append(unit.text)
+        }
+
+        guard !unspokenUnits.isEmpty else { return (nil, hasDeferredUnterminatedUnit) }
+        return (unspokenUnits.joined(separator: " "), hasDeferredUnterminatedUnit)
+    }
+
+    private static func speechUnits(from text: String) -> [SpeechUnit] {
+        var units: [SpeechUnit] = []
+        var currentUnit = ""
+        let terminators = CharacterSet(charactersIn: ".!?。！？\n")
+
+        for scalar in text.unicodeScalars {
+            currentUnit.unicodeScalars.append(scalar)
+            if terminators.contains(scalar) {
+                let unit = speechReadyText(currentUnit)
+                if !unit.isEmpty {
+                    units.append(SpeechUnit(text: unit, isTerminated: true))
+                }
+                currentUnit = ""
+            }
+        }
+
+        let remainingUnit = speechReadyText(currentUnit)
+        if !remainingUnit.isEmpty {
+            units.append(SpeechUnit(text: remainingUnit, isTerminated: false))
+        }
+
+        return units
+    }
+
+    private mutating func canSpeakStreamingUnit(
+        _ unit: SpeechUnit,
+        key: String,
+        at currentTime: Date
+    ) -> Bool {
+        defer {
+            if pendingStreamingUnit?.key != key {
+                pendingStreamingUnit = PendingStreamingUnit(
+                    key: key,
+                    text: unit.text,
+                    firstSeenAt: currentTime
+                )
+            }
+        }
+
+        guard let pendingStreamingUnit,
+              pendingStreamingUnit.key == key
+        else {
+            return false
+        }
+
+        return currentTime.timeIntervalSince(pendingStreamingUnit.firstSeenAt)
+            >= Self.minimumStreamingSpeechDwell
+    }
+
+    private static func normalizedSpeechUnitKey(_ text: String, languageID: String) -> String {
+        let foldedText = text.folding(
+            options: [.caseInsensitive, .diacriticInsensitive],
+            locale: Locale(identifier: languageID)
+        )
+        let allowedCharacters = CharacterSet.letters
+            .union(.decimalDigits)
+            .union(.whitespacesAndNewlines)
+        let filteredText = String(foldedText.unicodeScalars.map { scalar in
+            allowedCharacters.contains(scalar) ? Character(scalar) : " "
+        })
+
+        return filteredText
+            .replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func isRecentlySpokenSuffixReplay(_ key: String) -> Bool {
+        let tokenCount = key.split(separator: " ").count
+        guard (1...3).contains(tokenCount) else { return false }
+
+        return spokenUnitKeyOrder.suffix(8).contains { entry in
+            Self.isWholeTokenSuffix(key, of: entry.key)
+        }
+    }
+
+    private func wasRecentlySpoken(_ key: String) -> Bool {
+        spokenUnitKeys.contains(key) || spokenUnitKeys.contains { spokenKey in
+            Self.bigramSimilarity(spokenKey, key) >= Self.nearDuplicateThreshold
+        }
+    }
+
+    private static func bigramSimilarity(_ lhs: String, _ rhs: String) -> Double {
+        let left = bigrams(lhs)
+        let right = bigrams(rhs)
+        guard !left.isEmpty, !right.isEmpty else { return 0 }
+
+        let overlap = left.intersection(right).count
+        return (2 * Double(overlap)) / Double(left.count + right.count)
+    }
+
+    private static func isNearDuplicateRevision(
+        previous: String,
+        current: String,
+        languageID: String
+    ) -> Bool {
+        guard !previous.isEmpty, previous != current else { return false }
+        guard !current.hasPrefix(previous), !previous.hasPrefix(current) else { return false }
+
+        let previousKey = normalizedSpeechUnitKey(previous, languageID: languageID)
+        let currentKey = normalizedSpeechUnitKey(current, languageID: languageID)
+        let previousLength = previousKey.filter { !$0.isWhitespace }.count
+        let currentLength = currentKey.filter { !$0.isWhitespace }.count
+        guard previousLength > 0 else { return false }
+
+        let lengthDifference = abs(previousLength - currentLength)
+        guard lengthDifference <= max(3, previousLength / 5) else { return false }
+        return bigramSimilarity(previousKey, currentKey) >= nearDuplicateThreshold
+    }
+
+    private static func bigrams(_ text: String) -> Set<String> {
+        let characters = Array(text.filter { !$0.isWhitespace })
+        guard characters.count >= 2 else { return [] }
+
+        return Set((0..<(characters.count - 1)).map { index in
+            String(characters[index...index + 1])
+        })
+    }
+
+    private static func isWholeTokenSuffix(_ suffix: String, of text: String) -> Bool {
+        guard text != suffix, text.hasSuffix(suffix) else { return false }
+        let prefixEnd = text.index(text.endIndex, offsetBy: -suffix.count)
+        guard prefixEnd > text.startIndex else { return false }
+        let previous = text[text.index(before: prefixEnd)]
+        return previous.isWhitespace
+    }
+
+    private mutating func rememberSpokenUnits(in text: String, languageID: String, at currentTime: Date) {
+        for unit in Self.speechUnits(from: text) {
+            let key = Self.normalizedSpeechUnitKey(unit.text, languageID: languageID)
+            if !key.isEmpty {
+                rememberSpokenUnitKey(key, at: currentTime)
+            }
+        }
+    }
+
+    private mutating func rememberSpokenUnitKey(_ key: String, at currentTime: Date) {
+        spokenUnitKeys.insert(key)
+        spokenUnitKeyOrder.append((key, currentTime))
+
+        while spokenUnitKeyOrder.count > Self.maximumRememberedSpeechUnits {
+            let removed = spokenUnitKeyOrder.removeFirst()
+            if !spokenUnitKeyOrder.contains(where: { $0.key == removed.key }) {
+                spokenUnitKeys.remove(removed.key)
+            }
+        }
+    }
+
+    private mutating func expireSpokenUnits(at currentTime: Date) {
+        while let first = spokenUnitKeyOrder.first,
+              currentTime.timeIntervalSince(first.rememberedAt) >= Self.rememberedSpeechUnitTTL {
+            let removed = spokenUnitKeyOrder.removeFirst()
+            if !spokenUnitKeyOrder.contains(where: { $0.key == removed.key }) {
+                spokenUnitKeys.remove(removed.key)
+            }
+        }
+    }
+
+    private static func commonPrefixLength(_ lhs: String, _ rhs: String) -> Int {
+        var length = 0
+        for (leftCharacter, rightCharacter) in zip(lhs, rhs) {
+            guard leftCharacter == rightCharacter else { break }
+            length += 1
+        }
+        return length
+    }
+}

--- a/Tests/AirTranslateCoreTests/DubbingSpeechProgressTests.swift
+++ b/Tests/AirTranslateCoreTests/DubbingSpeechProgressTests.swift
@@ -1,0 +1,176 @@
+import Foundation
+import Testing
+@testable import AirTranslateCore
+
+@Suite
+struct DubbingSpeechProgressTests {
+    @Test
+    func shorterStreamingRewriteDoesNotMakeRestoredSentenceSpeakTail() {
+        var progress = DubbingSpeechProgress()
+
+        #expect(progress.unspokenText(
+            from: "We will focus on real-time translation.",
+            languageID: "en-US",
+            isFinal: true
+        ) == "We will focus on real-time translation.")
+        #expect(progress.unspokenText(from: "We will focus", languageID: "en-US") == nil)
+        #expect(progress.unspokenText(
+            from: "We will focus on real-time translation.",
+            languageID: "en-US"
+        ) == nil)
+        #expect(progress.unspokenText(
+            from: "We will focus on real-time translation. Next sentence.",
+            languageID: "en-US",
+            isFinal: true
+        ) == "Next sentence.")
+    }
+
+    @Test
+    func streamingTextRequiresTerminatorAndStabilityBeforeSpeech() {
+        var currentDate = Date(timeIntervalSinceReferenceDate: 100)
+        var progress = DubbingSpeechProgress(now: { currentDate })
+
+        #expect(progress.unspokenText(
+            from: "We will focus on real-time translation",
+            languageID: "en-US"
+        ) == nil)
+
+        currentDate = currentDate.addingTimeInterval(0.3)
+        #expect(progress.unspokenText(
+            from: "We will focus on real-time translation.",
+            languageID: "en-US"
+        ) == nil)
+
+        currentDate = currentDate.addingTimeInterval(0.91)
+        #expect(progress.unspokenText(
+            from: "We will focus on real-time translation.",
+            languageID: "en-US"
+        ) == "We will focus on real-time translation.")
+    }
+
+    @Test
+    func finalUnterminatedTranslationSpeaksImmediately() {
+        var progress = DubbingSpeechProgress()
+
+        #expect(progress.unspokenText(
+            from: "Final translation without punctuation",
+            languageID: "en-US",
+            isFinal: true
+        ) == "Final translation without punctuation")
+    }
+
+    @Test
+    func sameSentenceRefinalizationRevisionIsAdoptedWithoutRepeating() {
+        var progress = DubbingSpeechProgress()
+
+        #expect(progress.unspokenText(
+            from: "We're going to focus on real-time translation.",
+            languageID: "en-US",
+            isFinal: true
+        ) == "We're going to focus on real-time translation.")
+        #expect(progress.unspokenText(
+            from: "We are going to focus on real-time translation.",
+            languageID: "en-US",
+            isFinal: true
+        ) == nil)
+        #expect(progress.unspokenText(
+            from: "We are going to focus on real-time translation. Please watch the captions.",
+            languageID: "en-US",
+            isFinal: true
+        ) == "Please watch the captions.")
+    }
+
+    @Test
+    func nearDuplicateFinalizationVariantIsSuppressed() {
+        var progress = DubbingSpeechProgress()
+
+        #expect(progress.unspokenText(
+            from: "今天我们关注实时翻译的发展。",
+            languageID: "zh-CN",
+            isFinal: true
+        ) != nil)
+        #expect(progress.unspokenText(
+            from: "今天我们关注实时翻译技术的发展。",
+            languageID: "zh-CN",
+            isFinal: true
+        ) == nil)
+    }
+
+    @Test
+    func appendedShortSentenceIsNotMistakenForRevision() {
+        var progress = DubbingSpeechProgress()
+
+        #expect(progress.unspokenText(
+            from: "The presentation is ready.",
+            languageID: "en-US",
+            isFinal: true
+        ) == "The presentation is ready.")
+        #expect(progress.unspokenText(
+            from: "The presentation is ready. Go.",
+            languageID: "en-US",
+            isFinal: true
+        ) == "Go.")
+    }
+
+    @Test
+    func shortSuffixTailReplayIsSuppressedAfterSpokenSentence() {
+        var progress = DubbingSpeechProgress()
+
+        #expect(progress.unspokenText(
+            from: "The meeting will start now.",
+            languageID: "en-US",
+            isFinal: true
+        ) == "The meeting will start now.")
+        #expect(progress.unspokenText(
+            from: "The meeting will start now. start now.",
+            languageID: "en-US",
+            isFinal: true
+        ) == nil)
+        #expect(progress.unspokenText(
+            from: "The meeting will start now. Please take your seats.",
+            languageID: "en-US",
+            isFinal: true
+        ) == "Please take your seats.")
+    }
+
+    @Test
+    func spokenMemoryExpiresSoLegitimateLaterRepeatsCanSpeak() {
+        var currentDate = Date(timeIntervalSinceReferenceDate: 200)
+        var progress = DubbingSpeechProgress(now: { currentDate })
+
+        #expect(progress.unspokenText(
+            from: "Please join the meeting.",
+            languageID: "en-US",
+            isFinal: true
+        ) == "Please join the meeting.")
+        #expect(progress.unspokenText(
+            from: "Please join the meeting. Please join the meeting.",
+            languageID: "en-US",
+            isFinal: true
+        ) == nil)
+
+        currentDate = currentDate.addingTimeInterval(46)
+        #expect(progress.unspokenText(
+            from: "Please join the meeting. Please join the meeting. Please join the meeting.",
+            languageID: "en-US",
+            isFinal: true
+        ) == "Please join the meeting.")
+    }
+
+    @Test
+    func primedExistingTranslationDoesNotSpeakWhenDubbingTurnsOn() {
+        var progress = DubbingSpeechProgress()
+
+        progress.prime(with: "Already visible translation.", languageID: "en-US")
+
+        #expect(progress.unspokenText(
+            from: "Already visible translation.",
+            languageID: "en-US"
+        ) == nil)
+        #expect(progress.unspokenText(
+            from: "Already visible translation. Newly translated sentence.",
+            languageID: "en-US",
+            isFinal: true
+        ) == "Newly translated sentence.")
+    }
+}

--- a/script/app_metadata.sh
+++ b/script/app_metadata.sh
@@ -2,8 +2,8 @@
 
 APP_NAME="${APP_NAME:-AirTranslate}"
 BUNDLE_ID="${BUNDLE_ID:-dev.appcaster.AirTranslate}"
-VERSION="${VERSION:-1.4.0}"
-BUILD_NUMBER="${BUILD_NUMBER:-${BUILD_NUMBER_DEFAULT:-140}}"
+VERSION="${VERSION:-1.4.1}"
+BUILD_NUMBER="${BUILD_NUMBER:-${BUILD_NUMBER_DEFAULT:-141}}"
 MIN_SYSTEM_VERSION="${MIN_SYSTEM_VERSION:-26.0}"
 CATEGORY="${CATEGORY:-public.app-category.productivity}"
 COPYRIGHT_TEXT="${COPYRIGHT_TEXT:-Copyright © 2026 AirTranslate. All rights reserved.}"

--- a/하네스성숙도기록.md
+++ b/하네스성숙도기록.md
@@ -14,8 +14,8 @@
 | 항목 | 상태 |
 | --- | --- |
 | 목표 반복 횟수 | 3회 |
-| 현재 기록된 실행 | 15회 |
-| 현재 단계 | 릴리즈 스킬 의미·권한·원격 검증 게이트 강화 |
+| 현재 기록된 실행 | 17회 |
+| 현재 단계 | AirTranslate 1.4.1 릴리즈 세트 원격 게시·검증 |
 | 완전 마스터 판정 | 조건부 통과 |
 
 ---
@@ -39,6 +39,8 @@
 | 13회차 | 2026-07-10 | AirTranslate 1.4.0 릴리즈 세트·로컬 커밋 | release/test/security/report + update-set audit + ZIP/DMG 검증 | Gemini Live 인증 키가 공식 WebSocket URL query에 있어 raw 네트워크 오류가 URL을 노출할 수 있었고, 릴리즈 빌드가 `local` Info.plist 분기를 사용했음; Developer ID 인증서 부재 | 모든 외부 Gemini 연결 오류를 안전한 공개 오류로 정제하는 회귀 테스트, release plist 분기, 1.4.0/140 문서·미공증 고지, 123개 테스트, ZIP/DMG/sha/codesign/secret 검증 | 인증 URL은 절대 사용자 오류에 전달하지 않고 release script는 배포 metadata를 생성; ad-hoc·미공증 산출물은 fenced 승인 전 공개 업로드 금지 | 실행 |
 | 14회차 | 2026-07-10 | 1.4.0 게시 후 다국어 README 내용 누락 교정 | release/report + localized README parity audit | 하네스에 README 갱신 규칙은 있었지만 update-set audit가 파일·버전 링크 존재만 확인해 실제 사용자-facing 변경 설명이 4개 README에 반영되지 않은 채 게시됨 | 영어·한국어·일본어·중국어 README에 장기 세션, 체크포인트, API 지연, 음성 backlog, 단축키·접근성 내용을 동기화하고 AGENTS에 의미 기반 README gate 추가 | 릴리즈의 Added/Changed/Fixed 주제마다 4개 README 대응 섹션 또는 release-note-only 사유를 기록하며, 버전 문자열 검사만으로 README gate를 통과시키지 않음 | 실행 |
 | 15회차 | 2026-07-10 | 반복 추가 요청 없이 릴리즈 세트 완결하도록 스킬 강화 | skill-creator + release/report + update-set positive/negative tests + 독립 적대 재심 | 최초 요청에 출시 권한이 포함돼도 이중 승인 규칙이 다시 멈췄고, 1차 스킬 개선도 단독 `release`를 과대 해석하며 공개 audit 환경변수 누락 시 README·링크·자산을 `SKIP`하는 fail-open 결함이 있었음 | 실행 동사 기반 Publication Authority, `PUBLIC_RELEASE=1` fail-closed audit, 주제별 네 README semantic checks, 세 release-link checks, 로컬·원격 자산 hash/secret 검증, 지정 파일별 버전 확인, 준비/게시완료 보고서 분리, AGENTS·soul 영구 규칙 | 명사형 요청은 게시하지 않고, 명시적 출시 요청은 게이트 후 재승인 없이 완료; 공개 audit는 README·링크·자산·버전 입력 하나라도 빠지면 실패하고 업로드 전후 자산 내부까지 검증 | 실행 |
+| 16회차 | 2026-07-24 | GitHub Issue #8 Apple Speech·Translation 더빙 반복 수정 | runtime-fix/implement/test/report | 초기 정책 초안이 미완성 꼬리 안정화·시간 만료·근접 중복을 모두 포괄하지 못했고 기본 Command Line Tools의 `swift test`에는 `Testing` 모듈이 없었음 | `DubbingSpeechProgress` 정책 분리, 0.9초 안정화·45초 TTL·근접 중복 필터·최종 번역 즉시 발화, 9개 집중 회귀 테스트, Xcode-beta 전체 132개 테스트와 앱 재실행 검증 | 더빙 변경은 스트리밍/최종/재확정/TTL/짧은 후속 문장을 한 테스트 묶음으로 검증하고 테스트는 전체 Xcode 도구체인으로 실행 | 실행 |
+| 17회차 | 2026-07-24 | Issue #8 수정 포함 AirTranslate 1.4.1 전체 릴리즈 | release/security/test/report + update-set audit + 원격 게시 검증 | 기본 Command Line Tools 테스트가 `Testing` 모듈 없이 실패했고 1차 보안 점검이 새 자산 생성 전에 실행되어 오래된 1.4.0 자산을 차단했으며 사용자 소유 릴리즈 노트 삭제가 워크트리에 공존했음 | Xcode-beta 도구체인 132개 테스트, 24개 다국어 README 의미 검사, 1.4.1/141 자산 생성 후 보안 재점검, 명시적 파일 allowlist staging, 원격 자산 재다운로드·hash/secret 검증 | 릴리즈 보안 게이트는 최종 자산 생성 뒤 실행하고 테스트는 전체 Xcode를 고정 사용하며 더러운 워크트리에서는 `git add -A` 대신 허용 목록만 stage | 실행 |
 
 ---
 


### PR DESCRIPTION
## Summary
- fix Apple-mode dubbing replay and tail repetition from issue #8
- add stable sentence gating, final-text handling, 45-second replay expiry, and near-duplicate suppression
- publish aligned 1.4.1/141 metadata, localized READMEs, changelog, release notes, and harness record

## Verification
- 132 tests across 16 suites
- release build and app launch verification
- public update-set audit with 24 localized semantic checks
- DMG, ZIP, checksum, code-signature, and secret scans

Closes #8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the app release to version 1.4.1.
  * Improved Apple-mode translated-speech streaming, including faster handling of final translations without punctuation.

* **Bug Fixes**
  * Prevented repeated sentence tails, near-duplicate finalizations, and short suffixes from being spoken again.
  * Improved dubbing transitions to avoid rereading text already visible or spoken.
  * Preserved legitimate repeated phrases after the replay-suppression period expires.

* **Documentation**
  * Updated release notes, version history, multilingual documentation, and download links for version 1.4.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->