### PR TITLE
fix: make transcript file saving opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The default workflow uses Apple frameworks. GPT Realtime, Gemini Live Translate,
 - **Apple by default:** Apple Speech and Apple Translation remain the baseline path.
 - **Optional API modes:** OpenAI Realtime Translation, Gemini Live Translate, and Meta Scribe can be enabled only when needed.
 - **Keychain storage:** OpenAI, Gemini, and Meta API keys are entered by the user and stored in macOS Keychain.
-- **Plain text history:** saved transcripts remain normal `.txt` files in Application Support.
+- **Optional plain text history:** transcript files are off by default and can be enabled from Settings; saved transcripts remain normal `.txt` files in Application Support.
 
 ![AirTranslate demo](docs/assets/airtranslate-readme-demo.gif)
 
@@ -288,7 +288,7 @@ swift test
 5. Press Start.
 6. Play meeting, lecture, video, interview, or stream audio on your Mac.
 7. Read the transcript and translation in the main workspace or floating caption window.
-8. Press Stop to save the current transcript.
+8. If you enabled **Save Transcript Files** in Settings > Transcript, press Stop to save the current transcript.
 
 ## Saved Transcripts
 
@@ -297,6 +297,8 @@ Saved transcripts are stored as plain text files:
 ```text
 ~/Library/Application Support/AirTranslate/Transcripts/*.txt
 ```
+
+Transcript file saving is off by default. Enable **Save Transcript Files** in Settings > Transcript to opt in. When it is off, transcript text stays in memory for the session and Stop or app quit does not create a `.txt` file.
 
 When source and translation are saved together, AirTranslate writes separate `_original.txt` and `_translation.txt` files while presenting them as one grouped item in the library UI.
 

--- a/Sources/AirTranslate/Models/AppText.swift
+++ b/Sources/AirTranslate/Models/AppText.swift
@@ -790,14 +790,26 @@ enum AppText {
         korean: "긴 세션 보호 모드를 사용합니다. 전체 텍스트 화면 갱신과 번역 폭주를 줄이고, 아주 긴 기록은 최근 부분만 렌더링합니다."
     )
     static let savedTranscripts = localized(english: "Saved Transcripts", korean: "저장된 기록", japanese: "保存済み記録", chineseSimplified: "已保存记录")
+    static let transcriptPersistence = localized(
+        english: "Save Transcript Files",
+        korean: "기록 파일 저장",
+        japanese: "記録ファイルを保存",
+        chineseSimplified: "保存记录文件"
+    )
+    static let transcriptPersistenceDescription = localized(
+        english: "When on, transcript text is saved as dated plain .txt files when capture stops or the app quits. When off, it stays in memory only.",
+        korean: "켜면 캡처 중지 또는 앱 종료 시 기록을 날짜가 붙은 일반 .txt 파일로 저장합니다. 끄면 메모리에만 유지됩니다.",
+        japanese: "オンにすると、キャプチャ停止時またはアプリ終了時に記録を日付付きのプレーンな .txt ファイルとして保存します。オフの場合はメモリ上だけに保持します。",
+        chineseSimplified: "开启后，停止采集或退出应用时会将记录保存为带日期的纯文本 .txt 文件。关闭后仅保留在内存中。"
+    )
     static let savedTranscriptContent = localized(
         english: "Saved Content",
         korean: "저장 내용"
     )
     static let autoSave = localized(english: "Auto-save", korean: "자동 저장")
     static let autoSaveDescription = localized(
-        english: "Transcript text is kept in memory while listening, then saved as a dated plain .txt file with a short content title when capture stops or the app quits.",
-        korean: "기록 중에는 메모리에 유지하고, 캡처 중지 또는 앱 종료 직전에 날짜와 짧은 내용 제목이 들어간 일반 .txt 파일로 저장됩니다."
+        english: "Choose which transcript text to save when transcript file saving is enabled.",
+        korean: "기록 파일 저장을 켰을 때 어떤 기록 텍스트를 저장할지 선택합니다."
     )
     static let openSaveFolder = localized(
         english: "Open Save Folder",
@@ -818,8 +830,8 @@ enum AppText {
         korean: "저장된 기록 확인, 수정, 삭제, 폴더 열기는 별도 관리 창에서 처리합니다."
     )
     static let savedEmpty = localized(
-        english: "Auto-saved transcripts will appear here.",
-        korean: "자동 저장된 기록이 여기에 표시됩니다."
+        english: "Saved transcript files will appear here when file saving is enabled.",
+        korean: "기록 파일 저장을 켜면 저장된 기록이 여기에 표시됩니다."
     )
     static let noSavedTranscriptSelected = localized(
         english: "Select a saved transcript.",

--- a/Sources/AirTranslate/Services/TranslationSessionStore.swift
+++ b/Sources/AirTranslate/Services/TranslationSessionStore.swift
@@ -77,6 +77,7 @@ private enum SettingsKey {
     static let providerVoiceOutputEnabled = "providerVoiceOutputEnabled"
     static let translatedVoiceVolume = "translatedVoiceVolume"
     static let isTranscriptLintEnabled = "isTranscriptLintEnabled"
+    static let isTranscriptPersistenceEnabled = "isTranscriptPersistenceEnabled"
     static let floatingCaptionDisplayMode = "floatingCaptionDisplayMode"
     static let floatingCaptionTextSize = "floatingCaptionTextSize"
     static let floatingCaptionLineCount = "floatingCaptionLineCount"
@@ -555,6 +556,18 @@ final class TranslationSessionStore {
     var isTranscriptLintEnabled = false {
         didSet { persistSelectedSettings() }
     }
+    var isTranscriptPersistenceEnabled = false {
+        didSet {
+            persistSelectedSettings()
+            guard !isTranscriptPersistenceEnabled else { return }
+
+            transcriptCheckpointTask?.cancel()
+            transcriptCheckpointTask = nil
+            activeAutosaveSourceText = ""
+            activeAutosaveTranslatedText = ""
+            activeAutosaveBaseFileName = nil
+        }
+    }
     var floatingCaptionDisplayMode = FloatingCaptionDisplayMode.originalAndTranslation {
         didSet {
             if isTranscribeOnlyMode, floatingCaptionDisplayMode != .original {
@@ -1017,8 +1030,10 @@ final class TranslationSessionStore {
         flushOpenAITerminalTranscriptMailbox()
         flushPendingRecognizedCaption()
         flushPendingCaptionPresentation()
-        let hadTranscriptToSave = !visibleTranscript().trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        let hadTranscriptToSave = isTranscriptPersistenceEnabled
+            && (!visibleTranscript().trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             || !activeAutosaveSourceText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            )
         let didSaveTranscript = flushPendingTranscriptSave()
         resetLiveSessionState(clearsVisibleLines: false)
         isPaused = false
@@ -2724,6 +2739,9 @@ final class TranslationSessionStore {
         if defaults.object(forKey: SettingsKey.isTranscriptLintEnabled) != nil {
             isTranscriptLintEnabled = defaults.bool(forKey: SettingsKey.isTranscriptLintEnabled)
         }
+        if defaults.object(forKey: SettingsKey.isTranscriptPersistenceEnabled) != nil {
+            isTranscriptPersistenceEnabled = defaults.bool(forKey: SettingsKey.isTranscriptPersistenceEnabled)
+        }
         if let modeID = defaults.string(forKey: SettingsKey.floatingCaptionDisplayMode),
            let mode = FloatingCaptionDisplayMode(rawValue: modeID) {
             if isTranscribeOnlyMode {
@@ -2838,6 +2856,7 @@ final class TranslationSessionStore {
         defaults.set(providerVoiceOutputEnabled, forKey: SettingsKey.providerVoiceOutputEnabled)
         defaults.set(translatedVoiceVolume, forKey: SettingsKey.translatedVoiceVolume)
         defaults.set(isTranscriptLintEnabled, forKey: SettingsKey.isTranscriptLintEnabled)
+        defaults.set(isTranscriptPersistenceEnabled, forKey: SettingsKey.isTranscriptPersistenceEnabled)
         defaults.set(
             (floatingCaptionDisplayModeBeforeTranscribeOnly ?? floatingCaptionDisplayMode).id,
             forKey: SettingsKey.floatingCaptionDisplayMode
@@ -2991,6 +3010,8 @@ final class TranslationSessionStore {
     }
 
     private func stageTranscriptForSave(_ sourceText: String, translatedText: String? = nil) {
+        guard isTranscriptPersistenceEnabled else { return }
+
         let sourceText = usesAppleCaptionRollover && lines.count > 1
             ? appleSavedSourceTranscriptText
             : sourceText.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -3009,7 +3030,7 @@ final class TranslationSessionStore {
     }
 
     private func scheduleTranscriptCheckpointIfNeeded() {
-        guard isRunning, transcriptCheckpointTask == nil else { return }
+        guard isTranscriptPersistenceEnabled, isRunning, transcriptCheckpointTask == nil else { return }
 
         let intervalMilliseconds = max(Int(transcriptCheckpointInterval * 1_000), 1)
         transcriptCheckpointTask = Task { @MainActor [weak self] in
@@ -3025,12 +3046,14 @@ final class TranslationSessionStore {
 
     @discardableResult
     private func checkpointPendingTranscriptSave() -> Bool {
-        persistPendingTranscriptSave(clearsStagedText: false, reloadsLibrary: false)
+        guard isTranscriptPersistenceEnabled else { return false }
+        return persistPendingTranscriptSave(clearsStagedText: false, reloadsLibrary: false)
     }
 
     @discardableResult
     private func flushPendingTranscriptSave() -> Bool {
-        persistPendingTranscriptSave(clearsStagedText: true, reloadsLibrary: true)
+        guard isTranscriptPersistenceEnabled else { return false }
+        return persistPendingTranscriptSave(clearsStagedText: true, reloadsLibrary: true)
     }
 
     @discardableResult
@@ -3038,6 +3061,8 @@ final class TranslationSessionStore {
         clearsStagedText: Bool,
         reloadsLibrary: Bool
     ) -> Bool {
+        guard isTranscriptPersistenceEnabled else { return false }
+
         let currentSourceText = usesAppleCaptionRollover && lines.count > 1
             ? appleSavedSourceTranscriptText
             : visibleTranscript().trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/AirTranslate/Views/SettingsView.swift
+++ b/Sources/AirTranslate/Views/SettingsView.swift
@@ -585,6 +585,14 @@ struct SettingsView: View {
             }
 
             SettingsToggleRow(
+                title: AppText.transcriptPersistence,
+                detail: AppText.transcriptPersistenceDescription,
+                systemImage: "externaldrive",
+                isOn: lockedSessionConfigurationBinding($session.isTranscriptPersistenceEnabled)
+            )
+            .disabled(isSessionConfigurationLocked)
+
+            SettingsToggleRow(
                 title: AppText.transcriptLint,
                 detail: AppText.transcriptLintDescription,
                 systemImage: "wand.and.sparkles",
@@ -1456,8 +1464,8 @@ private enum SettingsCopy {
         korean: "표시할 결과와 번역 음성 출력을 조정합니다."
     )
     static let transcriptDetail = AppText.localized(
-        english: "Tune paragraphing, long sessions, and saved transcript behavior.",
-        korean: "문단 나누기, 긴 세션, 저장 기록 동작을 조정합니다."
+        english: "Tune paragraphing, long sessions, and optional transcript file saving.",
+        korean: "문단 나누기, 긴 세션, 선택적 기록 파일 저장을 조정합니다."
     )
     static let floatingDetail = AppText.localized(
         english: "Configure the detachable floating caption window.",

--- a/Sources/AirTranslate/Views/TranscriptLibraryView.swift
+++ b/Sources/AirTranslate/Views/TranscriptLibraryView.swift
@@ -81,7 +81,7 @@ struct TranscriptLibraryView: View {
                         .font(AirTranslateDesign.Typography.stageTitle)
                         .foregroundStyle(AirTranslateDesign.Palette.textPrimary)
 
-                    Text(AppText.autoSaveDescription)
+                    Text(AppText.transcriptPersistenceDescription)
                         .font(AirTranslateDesign.Typography.meta)
                         .foregroundStyle(AirTranslateDesign.Palette.textSecondary)
                         .lineLimit(2)
@@ -179,7 +179,7 @@ struct TranscriptLibraryView: View {
                     .font(AirTranslateDesign.Typography.stageTitle)
                     .foregroundStyle(AirTranslateDesign.Palette.textPrimary)
 
-                Text(AppText.autoSaveDescription)
+                Text(AppText.transcriptPersistenceDescription)
                     .font(AirTranslateDesign.Typography.meta)
                     .foregroundStyle(AirTranslateDesign.Palette.textSecondary)
                     .multilineTextAlignment(.center)

--- a/Tests/AirTranslateCoreTests/AppleCaptionRolloverTests.swift
+++ b/Tests/AirTranslateCoreTests/AppleCaptionRolloverTests.swift
@@ -7,8 +7,9 @@ struct AppleCaptionRolloverTests {
     @Test
     @MainActor
     func rolloverStartsNewLineAfterCommittedTextGrows() async throws {
-        let (session, directory) = try makeTranscriptionSession()
+        let (session, directory, settingsSuiteName) = try makeTranscriptionSession()
         defer { try? FileManager.default.removeItem(at: directory) }
+        defer { UserDefaults.standard.removePersistentDomain(forName: settingsSuiteName) }
         let transcriber = LiveSpeechTranscriber()
 
         let latestSentence = await feedUntilRollover(session: session, transcriber: transcriber)
@@ -23,8 +24,9 @@ struct AppleCaptionRolloverTests {
     @Test
     @MainActor
     func replayOfFinalizedSentenceAfterRolloverIsNotDuplicated() async throws {
-        let (session, directory) = try makeTranscriptionSession()
+        let (session, directory, settingsSuiteName) = try makeTranscriptionSession()
         defer { try? FileManager.default.removeItem(at: directory) }
+        defer { UserDefaults.standard.removePersistentDomain(forName: settingsSuiteName) }
         let transcriber = LiveSpeechTranscriber()
 
         _ = await feedUntilRollover(session: session, transcriber: transcriber)
@@ -53,8 +55,9 @@ struct AppleCaptionRolloverTests {
     @Test
     @MainActor
     func longSilenceRollsOverSmallerBlocks() async throws {
-        let (session, directory) = try makeTranscriptionSession()
+        let (session, directory, settingsSuiteName) = try makeTranscriptionSession()
         defer { try? FileManager.default.removeItem(at: directory) }
+        defer { UserDefaults.standard.removePersistentDomain(forName: settingsSuiteName) }
         let transcriber = LiveSpeechTranscriber()
         session.paragraphBreakSilenceInterval = 0.05
 
@@ -76,8 +79,9 @@ struct AppleCaptionRolloverTests {
     @Test
     @MainActor
     func savedTranscriptContainsAllRolledOverLines() async throws {
-        let (session, directory) = try makeTranscriptionSession()
+        let (session, directory, settingsSuiteName) = try makeTranscriptionSession()
         defer { try? FileManager.default.removeItem(at: directory) }
+        defer { UserDefaults.standard.removePersistentDomain(forName: settingsSuiteName) }
         let transcriber = LiveSpeechTranscriber()
 
         let latestSentence = await feedUntilRollover(session: session, transcriber: transcriber)
@@ -91,8 +95,9 @@ struct AppleCaptionRolloverTests {
     @Test
     @MainActor
     func perUpdateWorkStaysBoundedAcrossManySentences() async throws {
-        let (session, directory) = try makeTranscriptionSession()
+        let (session, directory, settingsSuiteName) = try makeTranscriptionSession()
         defer { try? FileManager.default.removeItem(at: directory) }
+        defer { UserDefaults.standard.removePersistentDomain(forName: settingsSuiteName) }
         let transcriber = LiveSpeechTranscriber()
 
         for index in 0..<200 {
@@ -105,13 +110,16 @@ struct AppleCaptionRolloverTests {
     }
 
     @MainActor
-    private func makeTranscriptionSession() throws -> (TranslationSessionStore, URL) {
+    private func makeTranscriptionSession() throws -> (TranslationSessionStore, URL, String) {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("AirTranslateAppleRolloverTests-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let settingsSuiteName = "AirTranslateAppleRolloverSettings-\(UUID().uuidString)"
+        let settingsDefaults = UserDefaults(suiteName: settingsSuiteName)!
         let session = TranslationSessionStore(
             modelAvailabilityProvider: { _, _ in [:] },
-            transcriptsDirectoryURL: directory
+            transcriptsDirectoryURL: directory,
+            settingsDefaults: settingsDefaults
         )
         session.useTranscribeOnlyMode()
         session.sourceLanguage = .english
@@ -122,7 +130,7 @@ struct AppleCaptionRolloverTests {
         session.isAppleSourceAutoDetectionEnabled = false
         session.paragraphBreakSilenceInterval = 30
         session.isRunning = true
-        return (session, directory)
+        return (session, directory, settingsSuiteName)
     }
 
     @MainActor

--- a/Tests/AirTranslateCoreTests/AppleCaptionRolloverTests.swift
+++ b/Tests/AirTranslateCoreTests/AppleCaptionRolloverTests.swift
@@ -117,6 +117,7 @@ struct AppleCaptionRolloverTests {
         session.sourceLanguage = .english
         session.targetLanguage = .korean
         session.sessionDurationMode = .standard
+        session.isTranscriptPersistenceEnabled = true
         session.savedTranscriptContentMode = .original
         session.isAppleSourceAutoDetectionEnabled = false
         session.paragraphBreakSilenceInterval = 30

--- a/Tests/AirTranslateCoreTests/AppleLifecycleP2Tests.swift
+++ b/Tests/AirTranslateCoreTests/AppleLifecycleP2Tests.swift
@@ -191,10 +191,14 @@ struct AppleLifecycleP2Tests {
             .appendingPathComponent("AirTranslateUserStopTests-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: directory) }
+        let settingsSuiteName = "AirTranslateUserStopSettings-\(UUID().uuidString)"
+        let settingsDefaults = UserDefaults(suiteName: settingsSuiteName)!
+        defer { settingsDefaults.removePersistentDomain(forName: settingsSuiteName) }
 
         let session = TranslationSessionStore(
             modelAvailabilityProvider: { _, _ in [:] },
-            transcriptsDirectoryURL: directory
+            transcriptsDirectoryURL: directory,
+            settingsDefaults: settingsDefaults
         )
         session.isTranscriptPersistenceEnabled = true
         session.savedTranscriptContentMode = .original

--- a/Tests/AirTranslateCoreTests/AppleLifecycleP2Tests.swift
+++ b/Tests/AirTranslateCoreTests/AppleLifecycleP2Tests.swift
@@ -196,6 +196,7 @@ struct AppleLifecycleP2Tests {
             modelAvailabilityProvider: { _, _ in [:] },
             transcriptsDirectoryURL: directory
         )
+        session.isTranscriptPersistenceEnabled = true
         session.savedTranscriptContentMode = .original
         let capture = session.systemAudioCaptureForTesting
         let firstPipeline = session.activateLiveCallbackPipelineForTesting()

--- a/Tests/AirTranslateCoreTests/LongSessionCaptionPresentationTests.swift
+++ b/Tests/AirTranslateCoreTests/LongSessionCaptionPresentationTests.swift
@@ -233,6 +233,7 @@ struct LongSessionCaptionPresentationTests {
         session.sourceLanguage = .english
         session.targetLanguage = .korean
         session.sessionDurationMode = .standard
+        session.isTranscriptPersistenceEnabled = true
         session.isAppleSourceAutoDetectionEnabled = false
         session.paragraphBreakSilenceInterval = 30
         session.isRunning = true

--- a/Tests/AirTranslateCoreTests/TranscriptPersistenceTests.swift
+++ b/Tests/AirTranslateCoreTests/TranscriptPersistenceTests.swift
@@ -1,0 +1,122 @@
+import Foundation
+import Testing
+@testable import AirTranslate
+
+@Suite(.serialized)
+struct TranscriptPersistenceTests {
+    @Test
+    @MainActor
+    func transcriptPersistenceIsOffByDefaultAndOptInPersists() throws {
+        let (session, directory, defaults, suiteName) = try makeSession()
+        defer { cleanup(directory: directory, defaults: defaults, suiteName: suiteName) }
+
+        #expect(!session.isTranscriptPersistenceEnabled)
+
+        session.isTranscriptPersistenceEnabled = true
+        let restored = TranslationSessionStore(
+            modelAvailabilityProvider: { _, _ in [:] },
+            settingsDefaults: defaults,
+            transcriptsDirectoryURL: directory
+        )
+
+        #expect(restored.isTranscriptPersistenceEnabled)
+    }
+
+    @Test
+    @MainActor
+    func stopDoesNotCreateTranscriptFilesWhenPersistenceIsDisabled() async throws {
+        let (session, directory, defaults, suiteName) = try makeSession()
+        defer { cleanup(directory: directory, defaults: defaults, suiteName: suiteName) }
+
+        await deliverTranscript("Stop must not persist this text.", to: session)
+        session.stop()
+
+        #expect(session.lines.last?.sourceText == "Stop must not persist this text.")
+        #expect(transcriptFiles(in: directory).isEmpty)
+    }
+
+    @Test
+    @MainActor
+    func quitDoesNotCreateTranscriptFilesWhenPersistenceIsDisabled() async throws {
+        let (session, directory, defaults, suiteName) = try makeSession()
+        defer { cleanup(directory: directory, defaults: defaults, suiteName: suiteName) }
+
+        await deliverTranscript("Quit must not persist this text.", to: session)
+        session.prepareForTermination()
+
+        #expect(session.lines.last?.sourceText == "Quit must not persist this text.")
+        #expect(transcriptFiles(in: directory).isEmpty)
+    }
+
+    @Test
+    @MainActor
+    func optInPersistenceStillWritesTheSelectedTranscriptContent() async throws {
+        let (session, directory, defaults, suiteName) = try makeSession()
+        defer { cleanup(directory: directory, defaults: defaults, suiteName: suiteName) }
+
+        session.isTranscriptPersistenceEnabled = true
+        await deliverTranscript("Opt-in persistence writes this text.", to: session)
+        session.stop()
+
+        let savedText = transcriptFiles(in: directory)
+            .compactMap { try? String(contentsOf: $0, encoding: .utf8) }
+            .joined(separator: "\n")
+        #expect(savedText.contains("Opt-in persistence writes this text."))
+    }
+
+    @MainActor
+    private func makeSession() throws -> (
+        TranslationSessionStore,
+        URL,
+        UserDefaults,
+        String
+    ) {
+        let suiteName = "TranscriptPersistenceTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AirTranslateTranscriptPersistenceTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        let session = TranslationSessionStore(
+            modelAvailabilityProvider: { _, _ in [:] },
+            settingsDefaults: defaults,
+            transcriptsDirectoryURL: directory
+        )
+        session.useTranscribeOnlyMode()
+        session.sourceLanguage = .english
+        session.targetLanguage = .japanese
+        session.isRunning = true
+        return (session, directory, defaults, suiteName)
+    }
+
+    @MainActor
+    private func deliverTranscript(_ text: String, to session: TranslationSessionStore) async {
+        let pipeline = session.activateLiveCallbackPipelineForTesting()
+        session.liveSpeechTranscriber(
+            pipeline.transcriber,
+            didRecognize: text,
+            language: .english,
+            confidence: 0.9
+        )
+
+        for _ in 0..<50 {
+            if session.lines.last?.sourceText == text {
+                return
+            }
+            await Task.yield()
+        }
+    }
+
+    private func transcriptFiles(in directory: URL) -> [URL] {
+        (try? FileManager.default.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        ))?.filter { $0.pathExtension == "txt" } ?? []
+    }
+
+    private func cleanup(directory: URL, defaults: UserDefaults, suiteName: String) {
+        defaults.removePersistentDomain(forName: suiteName)
+        try? FileManager.default.removeItem(at: directory)
+    }
+}


### PR DESCRIPTION
## Summary

AirTranslate now keeps live transcripts in memory by default and writes plain-text history only after explicit opt-in. This removes automatic transcript retention on Stop and Quit while preserving the saved-transcript workflow for users who enable it.

## Validation

- `swift build` passed against AirTranslate 1.7.1 on macOS 26 with Swift 6.3.2.
- `./script/verify_packaging_permissions.sh` passed.
- The audited 1.7.0 source build produced English-to-Japanese Apple Mode captions with no network sockets and zero transcript files after Stop and graceful Quit.
- `swift test` is blocked before execution because the installed Command Line Tools do not provide the Swift `Testing` module. New default-off, Stop, Quit, and opt-in persistence tests are included and discovered by the test build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a **Save Transcript Files** setting under **Settings > Transcript**.
  - Transcript files are saved only when enabled, when capture stops or the app quits.
  - The setting is remembered between sessions.
  - When disabled, transcripts remain in memory and no `.txt` file is created.

- **Documentation**
  - Updated transcript settings, usage instructions, and saved transcript guidance to explain the opt-in behavior.

- **Tests**
  - Added coverage for disabled-by-default behavior, setting restoration, lifecycle handling, and selected transcript content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->